### PR TITLE
Add a logger for logging the state updates and actions

### DIFF
--- a/eiffel/src/main/java/com/etiennelenhart/eiffel/Eiffel.kt
+++ b/eiffel/src/main/java/com/etiennelenhart/eiffel/Eiffel.kt
@@ -1,0 +1,130 @@
+package com.etiennelenhart.eiffel
+
+import android.app.Application
+import android.util.Log
+import com.etiennelenhart.eiffel.viewmodel.EiffelViewModel
+
+/**
+ * Debug logging utility for logging all actions and state updates.
+ *
+ * Logging can be enabled globally by calling [EiffelLogger.enable] or on a per [EiffelViewModel]
+ * basis by overriding [EiffelViewModel.isDebugMode].
+ *
+ * Allows the ability to supply custom logging class.
+ *
+ * @sample
+ * ```
+ * // Create a logging class
+ * class TimberLogger : Logger {
+ *    override fun log(tag: String, msg: String) {
+ *        Timber.tag(tag).d(msg)
+ *    }
+ * }
+ *
+ * // Supply it to the constructor
+ * EiffelLogger(TimberLogger())
+ * ```
+ *
+ * @param[logger] Logging interface, defaults to [Log].
+ */
+class EiffelLogger(
+    private var logger: Logger? = null
+) {
+
+    init {
+        if (logger == null) logger = defaultLogger
+    }
+
+    /**
+     * Log a message without a custom tag.
+     *
+     * @param[msg] Message to log.
+     */
+    internal fun log(msg: String) {
+        logger?.log(tagPrefix, msg)
+    }
+
+    /**
+     * Log a message with a custom tag.
+     *
+     * @sample
+     * ```
+     * EiffelLogger().log("SomeViewModel", "Message")
+     *
+     * // Logs:
+     * // D/Eiffel:SomeViewModel: Message
+     *
+     * @param[tag] Custom tag to append to the [tagPrefix].
+     * @param[msg] Message to log.
+     */
+    internal fun log(tag: String, msg: String) {
+        logger?.log("$tagPrefix:$tag", msg)
+    }
+
+    companion object {
+
+        /**
+         * Prefix to add to the log tag.
+         */
+        private const val tagPrefix: String = "Eiffel"
+
+        /**
+         * Default logging interface, defaults to [DefaultLogger] which logs with [Log].
+         */
+        private var defaultLogger: Logger? = null
+
+        /**
+         * Check if [EiffelLogger.enable] has been called globally.
+         */
+        val isEnabled: Boolean
+            get() = defaultLogger != null
+
+        /**
+         * Static function to enable the logger globally.
+         *
+         * Useful if you do not want to manually enable the logger in each [EiffelViewModel].  It
+         * can be enabled anywhere, but a good place is in your [Application] entry point.
+         *
+         * @sample
+         * ```
+         * class App : Application() {
+         *
+         *    override onCreate() {
+         *       super.onCreate()
+         *
+         *       Timber.plant(DebugTree())
+         *
+         *       EiffelLogger.enable(object: Logger {
+         *          override log(tag: String, message: String) {
+         *             Timber.tag(tag).d(message)
+         *          }
+         *       })
+         *    }
+         * }
+         * ```
+         *
+         * @param[logger] Logger interface, defaults to [Log].
+         */
+        fun enable(logger: Logger = DefaultLogger()) {
+            defaultLogger = logger
+        }
+    }
+
+    /**
+     * Abstraction for providing a custom logging solution.
+     */
+    interface Logger {
+
+        fun log(tag: String, msg: String)
+    }
+
+    /**
+     * A default logger implementation that uses [Log] to log the messages
+     */
+    private class DefaultLogger : Logger {
+
+        override fun log(tag: String, msg: String) {
+            Log.d(tag, msg)
+        }
+    }
+}


### PR DESCRIPTION
## What's new

References #60 

I have thrown together a quick implementation of a debug logger.  It currently logs dispatched `Action`'s, `State` updates, and `Interception`'s.  I added the interception logging because I thought it might be helpful.  But I'm not entirely sure if it is needed, or a more complex solution needs to be created for it.

## How to use

The logger can be enabled in two ways.  On a per-ViewModel basis, and globally.

Globally:

```kotlin
class App : Application() {

    override onCreate() {
        super.onCreate()
        Timber.plant(DebugTree())
        
         // Default android.util.Log logger
         EiffelLogger.enable()

         // Custom logger, ie: using Timber
         EiffelLogger.enable(object: Logger {
               override log(tag: String, message: String) {
                    Timber.tag(tag).d(message)
                }
          })
     }
}
```

Or on a per-viewmodel basis:

```kotlin
class SomeViewModel : EiffelViewModel<State, Action(...) {
    
     // Can also be implemented as a constructor parameter
    override isDebugMode() = true
}
```

By default each messaged logged will have a tag of "Eiffel", and if you supply a custom tag when calling `EiffelLogger.log` then it will be appended.  

ex:

```kotlin
logger.log("SomeViewModel", "Message...")

// logs -> "Eiffel:SomeViewModel: Message..."
```

The logging implementation can also be overriden globally or via the `EiffelViewModel`.  So you can pass a custom logging solution into `EiffelLogger`. 

ex:  A Timber logger

```kotlin
class TimberLogger : Logger {
   override log(tag: String, message: String) {
        Timber.tag(tag).d(message)
    }
}

EiffelLogger.enable(TimberLogger())
```

Let me know what you think 👍 