### PR TITLE
Feature Proposal - Plugin Support

### DIFF
--- a/eiffel/src/main/java/com/etiennelenhart/eiffel/DebugConfig.kt
+++ b/eiffel/src/main/java/com/etiennelenhart/eiffel/DebugConfig.kt
@@ -1,0 +1,59 @@
+package com.etiennelenhart.eiffel
+
+import com.etiennelenhart.eiffel.plugin.Dispatcher
+import com.etiennelenhart.eiffel.plugin.EiffelPlugin
+import com.etiennelenhart.eiffel.plugin.event.Event
+import com.etiennelenhart.eiffel.plugin.logger.DefaultLoggerPlugin
+import com.etiennelenhart.eiffel.plugin.logger.LoggerPlugin
+import com.etiennelenhart.eiffel.viewmodel.EiffelViewModel
+
+/**
+ * The config for the Debug feature of Eiffel.
+ */
+internal interface DebugConfig {
+
+    /**
+     * Global flag for enabling/disabling debug mode.
+     *
+     * Can be overridden on a per-ViewModel basis.
+     * @see EiffelViewModel.debug
+     */
+    val enabled: Boolean
+
+    /**
+     * Plugins that will react to [Event]'s dispatched by a [EiffelViewModel].
+     *
+     * Currently there is one supplied plugin for logging to the logcat.
+     * @see LoggerPlugin
+     */
+    val plugins: List<EiffelPlugin>
+
+    /**
+     * Custom implementation for dispatching an [Event].
+     * @see Dispatcher
+     */
+    val dispatcher: Dispatcher
+
+    /**
+     * The default implementation for [DebugConfig].
+     *
+     * Call [Eiffel.debugMode] to enable debug mode and set a new config.
+     */
+    object Default : DebugConfig {
+
+        /**
+         * Default the debug mode to disabled.
+         */
+        override val enabled = false
+
+        /**
+         * Default to use the [DefaultLoggerPlugin] for logging [Event]'s to the logcat.
+         */
+        override val plugins = listOf<EiffelPlugin>(DefaultLoggerPlugin())
+
+        /**
+         * Use the default [Dispatcher].
+         */
+        override val dispatcher = Dispatcher.Default
+    }
+}

--- a/eiffel/src/main/java/com/etiennelenhart/eiffel/Eiffel.kt
+++ b/eiffel/src/main/java/com/etiennelenhart/eiffel/Eiffel.kt
@@ -1,0 +1,97 @@
+package com.etiennelenhart.eiffel
+
+import com.etiennelenhart.eiffel.plugin.Dispatcher
+import com.etiennelenhart.eiffel.plugin.EiffelPlugin
+import com.etiennelenhart.eiffel.plugin.event.Event
+import com.etiennelenhart.eiffel.plugin.logger.DefaultLoggerPlugin
+import com.etiennelenhart.eiffel.plugin.logger.LoggerPlugin
+
+/**
+ * Static Eiffel object containing all config and debug logic
+ */
+object Eiffel {
+
+    /**
+     * Debug configuration.
+     *
+     * Defaults to [DebugConfig.Default], but can be overridden by calling [debugMode].
+     */
+    internal var debugConfig: DebugConfig = DebugConfig.Default
+        private set
+
+    /**
+     * Enable or disable Eiffel's debug mode.
+     *
+     * @sample
+     * Basic example:
+     * ```
+     * class MyDebugApp : Application {
+     *
+     *   override onCreate() {
+     *      super.onCreate()
+     *
+     *      // By default a LoggerPlugin is added
+     *      Eiffel.debugMode(true)
+     *   }
+     * }
+     *
+     * class MyReleaseApp : Application {
+     *
+     *   override onCreate() {
+     *      super.onCreate()
+     *
+     *      // Never log anything in production
+     *      Eiffel.debugMode(true, listOf(ReleaseLoggerPlugin()))
+     *   }
+     * }
+     * ```
+     *
+     * @sample
+     * Complex example
+     * ```
+     * Eiffel.debugMode(
+     *    enabled = true,
+     *    plugins = listOf(
+     *       DefaultLoggerPlugin(
+     *         logger = log { priority, tag, message ->
+     *             Timber.tag(tag).log(priority, message)
+     *         },
+     *         transformer = transform { event -> "Event: ${event.toString()}" }
+     *       )
+     *    )
+     * )
+     * ```
+     *
+     * @param[enabled] Globally enable the debug mode for the whole app.
+     * @param[plugins] Eiffel plugins to use.
+     * @param[dispatcher] Implementation for dispatching the [Event].
+     */
+    fun debugMode(
+        enabled: Boolean,
+        plugins: List<EiffelPlugin> = listOf(),
+        dispatcher: Dispatcher = Dispatcher.Default
+    ) {
+        debugConfig = object : DebugConfig {
+            override val enabled: Boolean = enabled
+            override val plugins: List<EiffelPlugin> = createPluginList(plugins)
+            override val dispatcher: Dispatcher = dispatcher
+        }
+    }
+
+    /**
+     * Create a list of plugins, ensuring that a [LoggerPlugin] always exists.
+     *
+     * @param[plugins] List of plugins to modify.
+     * @return List of [EiffelPlugin] with a guaranteed [LoggerPlugin].
+     */
+    private fun createPluginList(plugins: List<EiffelPlugin>) = plugins
+        .toMutableList()
+        .let { list ->
+            val hasLogger = list.find { it is LoggerPlugin<*> } != null
+            if (!hasLogger) list.add(0, DefaultLoggerPlugin())
+
+            return@let list
+        }
+        .toList()
+}
+

--- a/eiffel/src/main/java/com/etiennelenhart/eiffel/plugin/Dispatcher.kt
+++ b/eiffel/src/main/java/com/etiennelenhart/eiffel/plugin/Dispatcher.kt
@@ -1,0 +1,120 @@
+package com.etiennelenhart.eiffel.plugin
+
+import com.etiennelenhart.eiffel.Eiffel
+import com.etiennelenhart.eiffel.interception.Interception
+import com.etiennelenhart.eiffel.plugin.Dispatcher.Default
+import com.etiennelenhart.eiffel.plugin.event.Event
+import com.etiennelenhart.eiffel.state.Action
+import com.etiennelenhart.eiffel.state.State
+import com.etiennelenhart.eiffel.state.Update
+import com.etiennelenhart.eiffel.viewmodel.EiffelViewModel
+import com.etiennelenhart.eiffel.viewmodel.name
+
+/**
+ * Used to customize how the [Event]'s are dispatched to the [EiffelPlugin].
+ *
+ * [Eiffel.debugMode] defaults to using [Default].
+ */
+interface Dispatcher {
+
+    /**
+     * Dispatch an event to each of the [EiffelPlugin].
+     *
+     * @see EiffelViewModel.dispatchEiffelEvent
+     * @param[dispatcher] String identifier tag for the class that dispatched the event.
+     * @param[event] The event to dispatch.
+     */
+    fun <E : Event> dispatchEvent(dispatcher: String, event: E)
+
+    /**
+     * A default [Dispatcher] used by [Eiffel.debugConfig].
+     */
+    object Default : Dispatcher {
+
+        /**
+         * Dispatches the event to all of the registered plugins.
+         *
+         * TODO - This may not be the best approach, maybe figure out a way not to use the static variable
+         *
+         * @see Dispatcher.dispatchEvent
+         */
+        override fun <E : Event> dispatchEvent(dispatcher: String, event: E) {
+            Eiffel.debugConfig.plugins.forEach { it.onEvent(dispatcher, event) }
+        }
+    }
+}
+
+/**
+ * Dispatch a custom message to all the plugins.
+ *
+ * @param[message] Custom message to dispatch.
+ */
+fun <S : State, A : Action> EiffelViewModel<S, A>.dispatchEiffelMessage(message: String) =
+    dispatchEiffelEvent(Event.Message(message))
+
+/**
+ * Dispatch a custom object to all the plugins.
+ *
+ * Ensure you override [data]'s [toString] so it can be logged properly.
+ *
+ * @param[data] Custom object to dispatch.
+ */
+fun <S : State, A : Action, T : Any> EiffelViewModel<S, A>.dispatchEiffelCustom(data: T) =
+    dispatchEiffelEvent(Event.Custom(data))
+
+/**
+ * Dispatches a [Event.ViewModelCreated] event with the class name of the updated [EiffelViewModel].
+ */
+internal fun <S : State, A : Action> EiffelViewModel<S, A>.dispatchEiffelCreated() =
+    dispatchEiffelEvent(Event.ViewModelCreated(name, state.value!!))
+
+/**
+ * Dispatches a [Event.Action] with the [Action].
+ *
+ * @param[action] The updated action dispatched by [EiffelViewModel.dispatchActor].
+ */
+internal fun <S : State, A : Action, T : A> EiffelViewModel<S, A>.dispatchEiffelAction(action: T) =
+    dispatchEiffelEvent(Event.Action(action))
+
+/**
+ * Dispatches a [Event.Update] with the previous and updated [State].
+ *
+ * @param[previous] The [State] before the [Update].
+ * @param[updated] The [State] after the [Update].
+ */
+internal fun <S : State, A : Action> EiffelViewModel<S, A>.dispatchEiffelUpdate(previous: S, updated: S) =
+    dispatchEiffelEvent(Event.Update(previous, updated))
+
+/**
+ * Dispatches a [Event.Interception] with the updated [State], [Action] and [Interception].
+ *
+ * @param[state] Current state of the [EiffelViewModel].
+ * @param[action] Current [Action] that the [Interception] is handling.
+ * @param[interception] The interception.
+ */
+internal fun <S : State, A : Action, I : Interception<S, A>> EiffelViewModel<S, A>.dispatchEiffelInterception(
+    state: S,
+    action: A,
+    interception: I
+) =
+    dispatchEiffelEvent(Event.Interception(state, action, interception))
+
+/**
+ * Dispatches a [Event.ViewModelCleared].
+ */
+internal fun <S : State, A : Action> EiffelViewModel<S, A>.dispatchEiffelCleared() =
+    dispatchEiffelEvent(Event.ViewModelCleared(name))
+
+/**
+ * Convenience function for dispatching an event from a [EiffelViewModel].
+ *
+ * It will only dispatch the event if the user has enabled global debug mode in their app, OR the
+ * [EiffelViewModel] has overridden the [EiffelViewModel.debug].
+ *
+ * @param[event] The [Event] to dispatch to the list of [EiffelPlugin].
+ */
+private fun <S : State, A : Action, E : Event> EiffelViewModel<S, A>.dispatchEiffelEvent(event: E) {
+    if (Eiffel.debugConfig.enabled || debug) {
+        Eiffel.debugConfig.dispatcher.dispatchEvent(name, event)
+    }
+}

--- a/eiffel/src/main/java/com/etiennelenhart/eiffel/plugin/EiffelPlugin.kt
+++ b/eiffel/src/main/java/com/etiennelenhart/eiffel/plugin/EiffelPlugin.kt
@@ -1,0 +1,30 @@
+package com.etiennelenhart.eiffel.plugin
+
+import com.etiennelenhart.eiffel.plugin.event.Event
+import com.etiennelenhart.eiffel.plugin.logger.LoggerPlugin
+
+/**
+ * Used to create a custom plugin for Eiffel.
+ *
+ * The current design only allows the plugin to view the event.  It currently has no power to
+ * manipulate or block the chain of plugins.  This may need to be explored in the future.
+ *
+ * @see LoggerPlugin
+ */
+interface EiffelPlugin {
+
+    /**
+     * Each plugin needs a name so it can be identified.
+     *
+     * Note: Not currently used, but may be in the future.
+     */
+    val name: String
+
+    /**
+     * All events will flow through each plugin.
+     *
+     * @param[dispatcher] A string tag of the class that dispatched the [Event].
+     * @param[event] The event that has been dispatched.
+     */
+    fun <E : Event> onEvent(dispatcher: String, event: E)
+}

--- a/eiffel/src/main/java/com/etiennelenhart/eiffel/plugin/event/Event.kt
+++ b/eiffel/src/main/java/com/etiennelenhart/eiffel/plugin/event/Event.kt
@@ -1,0 +1,87 @@
+package com.etiennelenhart.eiffel.plugin.event
+
+import com.etiennelenhart.eiffel.plugin.Dispatcher
+import com.etiennelenhart.eiffel.plugin.EiffelPlugin
+import com.etiennelenhart.eiffel.state.State
+import com.etiennelenhart.eiffel.viewmodel.EiffelViewModel
+import com.etiennelenhart.eiffel.interception.Interception as StateInterception
+import com.etiennelenhart.eiffel.state.Action as StateAction
+
+/**
+ * Events that an [EiffelPlugin] can interact with.
+ *
+ * Using a sealed class to make it easier when transforming the [Event] with
+ * a [TransformEventMessage]. See [TransformEventMessage.defaultStringTransformer] for a default
+ * implementation of a transformer.
+ *
+ * They are dispatched by a [Dispatcher].
+ *
+ * @param[tag] A String tag to represent what kind of event is being dispatched, useful for logging.
+ */
+sealed class Event(val tag: String = "") {
+
+    /**
+     * An [Event] indicating that a [EiffelViewModel] has been created.
+     *
+     * @param[name] Class name of the [EiffelViewModel].
+     * @param[initialState] The initial state of the ViewModel.
+     */
+    data class ViewModelCreated<S : State>(val name: String, val initialState: S) : Event()
+
+    /**
+     * An [Event] indicating that a [EiffelViewModel]'s [EiffelViewModel.onCleared] has been called.
+     *
+     * @param[name] Class name of the [EiffelViewModel].
+     */
+    data class ViewModelCleared(val name: String) : Event()
+
+    /**
+     * An [Event] for dispatching a custom message.
+     *
+     * Useful if the developer wants to log something during development.
+     *
+     * @param[message] Custom message.
+     */
+    data class Message(val message: String) : Event("Message")
+
+    /**
+     * An [Event] for dispatching a custom object.
+     *
+     * Ensure you override the [toString] of [data] so that it can be properly converting to a
+     * string by the logger.
+     *
+     * @param[data] Custom object type.
+     */
+    data class Custom<T : Any>(val data: T) : Event()
+
+    /**
+     * An [Event] indicating the updated [Action] being handled by the [EiffelViewModel].
+     *
+     * @param[action] Dispatched [Action].
+     */
+    data class Action<A : StateAction>(val action: A) : Event("Action")
+
+    /**
+     * An [Event] for tracking updates to the [EiffelViewModel.state].
+     *
+     * If you have [State] objects that are very large, like a list of complex objects.  You can
+     * override the [toString] of your state.  That way you can control what gets logged.
+     *
+     * @param[previous] The state before the [Update] was called.
+     * @param[updated] The updated state.
+     */
+    data class Update<S : State>(val previous: S, val updated: S) : Event("Update")
+
+    /**
+     * An [Event] indicating the current [Interception].
+     *
+     * @param[currentState] Current state at the time of the [Interception].
+     * @param[action] Action that triggered the [Interception].
+     * @param[interception] The current active [Interception].
+     */
+    data class Interception<S : State, A : StateAction, I : StateInterception<S, A>>(
+        val currentState: S,
+        val action: A,
+        val interception: I
+    ) : Event("Interception")
+}

--- a/eiffel/src/main/java/com/etiennelenhart/eiffel/plugin/event/TransformEventMessage.kt
+++ b/eiffel/src/main/java/com/etiennelenhart/eiffel/plugin/event/TransformEventMessage.kt
@@ -1,0 +1,80 @@
+package com.etiennelenhart.eiffel.plugin.event
+
+import com.etiennelenhart.eiffel.plugin.event.TransformEventMessage.Default
+import com.etiennelenhart.eiffel.plugin.event.TransformEventMessage.Default.defaultStringTransformer
+import com.etiennelenhart.eiffel.plugin.event.TransformEventMessage.Default.toString
+import com.etiennelenhart.eiffel.plugin.logger.LoggerPlugin
+import com.etiennelenhart.eiffel.state.State
+
+/**
+ * Used to customize how an [Event] is transformed for use with a plugin.
+ *
+ * For example, the [LoggerPlugin] requires the [Event] to be converted to a string.  There is a
+ * default transformer [Default], which transforms them into a string for the log.
+ *
+ * Say you had a plugin that needed the [Event]'s as a JSON object.  Well you could create a
+ * [TransformEventMessage] that uses a library to convert it to JSON (like moshi or GSON).
+ *
+ * @param[T] Type to convert the [Event] to.
+ */
+interface TransformEventMessage<T> {
+
+    /**
+     * Transformer lambda that [Event] into [T].
+     */
+    val transformer: (Event) -> T
+
+    /**
+     * Default implementation of a [TransformEventMessage] that transforms [Event] to [String].
+     *
+     * Warning: Some [Event]'s contain a [State] reference.  If that has a lot of complex data,
+     * it may pollute the logcat. You can trim some of the clutter by overriding the [toString] of the [State].
+     *
+     * @see defaultStringTransformer
+     */
+    object Default : TransformEventMessage<String> {
+        override val transformer: (Event) -> String = { defaultStringTransformer(it) }
+    }
+
+    /**
+     * A default transformer that takes an [Event] and returns a [LoggerPlugin] appropriate [String].
+     *
+     * @param[event] Event to transform.
+     */
+    fun defaultStringTransformer(event: Event): String = when (event) {
+        is Event.Message -> "Received message: ${event.message}"
+        is Event.Custom<*> -> event.data.toString()
+        is Event.ViewModelCreated<*> -> "Created ${event.name} - Initial state: ${event.initialState}"
+        is Event.ViewModelCleared -> "Cleared ${event.name}"
+        is Event.Action<*> -> "Dispatching action: ${event.action}"
+        is Event.Update<*> -> """
+            ->
+            State Update:
+                Previous: ${event.previous}
+                Updated: ${event.updated}
+            """.trimIndent()
+        is Event.Interception<*, *, *> -> """
+            ->
+            Applying ${event.interception::class.java.simpleName}:
+                Action: ${event.action}
+                State: ${event.currentState}
+            """.trimIndent()
+    }
+}
+
+/**
+ * Convenience function for creating a [TransformEventMessage].
+ *
+ * Scoped to the [TransformEventMessage] so the lambda can access [defaultStringTransformer].
+ *
+ * @param[transformer] A lambda expression for transforming the [Event].
+ */
+inline fun <T> transformEvent(
+    crossinline transformer: TransformEventMessage<T>.(event: Event) -> T
+): TransformEventMessage<T> {
+    return object : TransformEventMessage<T> {
+        override val transformer: (Event) -> T = { event ->
+            transformer(this, event)
+        }
+    }
+}

--- a/eiffel/src/main/java/com/etiennelenhart/eiffel/plugin/logger/Logger.kt
+++ b/eiffel/src/main/java/com/etiennelenhart/eiffel/plugin/logger/Logger.kt
@@ -1,0 +1,46 @@
+package com.etiennelenhart.eiffel.plugin.logger
+
+import android.util.Log
+import com.etiennelenhart.eiffel.plugin.logger.Logger.Default
+
+/**
+ * Can be used by [LoggerPlugin] to override the default behaviour of [Default].
+ *
+ * For example you could create a [Logger] object that uses Timber or some other
+ * custom logging library.
+ *
+ * @see DefaultLoggerPlugin
+ */
+interface Logger {
+
+    fun log(priority: Int, tag: String, message: String)
+
+    /**
+     * A default [Logger] that will just pass the values to [Log.println]
+     */
+    object Default : Logger {
+        override fun log(priority: Int, tag: String, message: String) {
+            Log.println(priority, tag, message)
+        }
+    }
+
+    /**
+     * A No-op version of [Logger] for release mode
+     */
+    object ReleaseLogger : Logger {
+        override fun log(priority: Int, tag: String, message: String) {}
+    }
+}
+
+/**
+ * Convenience function for building a [Logger].
+ *
+ * @param[logger] Lambda expression to log the event.
+ */
+inline fun log(crossinline logger: (priority: Int, tag: String, message: String) -> Unit): Logger {
+    return object : Logger {
+        override fun log(priority: Int, tag: String, message: String) {
+            logger(priority, tag, message)
+        }
+    }
+}

--- a/eiffel/src/main/java/com/etiennelenhart/eiffel/plugin/logger/LoggerPlugin.kt
+++ b/eiffel/src/main/java/com/etiennelenhart/eiffel/plugin/logger/LoggerPlugin.kt
@@ -1,0 +1,110 @@
+package com.etiennelenhart.eiffel.plugin.logger
+
+import android.util.Log
+import com.etiennelenhart.eiffel.Eiffel
+import com.etiennelenhart.eiffel.plugin.EiffelPlugin
+import com.etiennelenhart.eiffel.plugin.event.Event
+import com.etiennelenhart.eiffel.plugin.event.TransformEventMessage
+import com.etiennelenhart.eiffel.plugin.event.transformEvent
+import com.etiennelenhart.eiffel.viewmodel.EiffelViewModel
+
+/**
+ * [EiffelPlugin] contract for creating a plugin to log [Event]'s to the logcat.
+ *
+ * @see DefaultLoggerPlugin
+ * @see ReleaseLoggerPlugin
+ */
+interface LoggerPlugin<T> : EiffelPlugin {
+
+    override val name: String
+        get() = "Logger"
+
+    val logger: Logger
+    val transform: TransformEventMessage<T>
+}
+
+/**
+ * A included [LoggerPlugin] for logging all of the [Event]'s to the logcat.
+ *
+ * [Eiffel.debugConfig] by default will include a [DefaultLoggerPlugin].  If you happen to pass in more
+ * plugins via [Eiffel.debugMode], then a [DefaultLoggerPlugin] will be added automatically.  If
+ * you have manually supplied a [LoggerPlugin] then only yours will be added.
+ *
+ * By default it uses the [Logger.Default] which uses [Log.println].  You can pass in a custom
+ * logging solution by supplying a [logger].
+ *
+ * You can also override the default behaviour of turning the [Event] into a string by passing
+ * in a [transform].  Say you wanted to export the event as a JSON string you could
+ * extend [TransformEventMessage] to create a POJO, then serialize it JSON using a library.
+ *
+ * @sample
+ * ```
+ * class MyApp : Application {
+ *
+ *   override onCreate() {
+ *      super.onCreate()
+ *
+ *      Eiffel.debugMode(true, listOf(
+ *          DefaultLoggerPlugin(
+ *             logger = log { priority, tag, message ->
+ *                Timber.tag(tag).log(priority, message)
+ *             }
+ *         )
+ *      ))
+ *   }
+ * }
+ * ```
+ *
+ * @see Logger
+ * @see log
+ * @see TransformEventMessage.Default
+ * @param[logger] Logger implementation for logging the events
+ * @param[transform] TransformEventMessage implementation for transforming events into String's
+ */
+class DefaultLoggerPlugin(
+    override val logger: Logger = Logger.Default,
+    override val transform: TransformEventMessage<String> = TransformEventMessage.Default
+) : LoggerPlugin<String> {
+
+    override fun <E : Event> onEvent(dispatcher: String, event: E) {
+        val eventMessage = transform.transformer(event)
+
+        val tag = if (event.tag.isEmpty()) "" else ":${event.tag}"
+        logger.log(Log.DEBUG, "Eiffel-$name:$dispatcher$tag", eventMessage)
+    }
+}
+
+/**
+ * A included [LoggerPlugin] for use with a release flavour of an app.
+ *
+ * It will not transform or log any output, use this if you would like to disable all
+ * logging in production. Use in production to ensure no logging will happen. As uou can
+ * disable [Eiffel]'s debug mode, but a [EiffelViewModel] might accidentally
+ * have overridden [EiffelViewModel.debug].
+ *
+ * @sample
+ * ```
+ * class MyReleaseApp : Application {
+ *
+ *   override onCreate() {
+ *      super.onCreate()
+ *
+ *      Eiffel.debugMode(false, listOf(ReleaseLoggerPlugin))
+ *   }
+ * }
+ * ```
+ *
+ * @see DefaultLoggerPlugin
+ * @see Eiffel.debugMode
+ */
+object ReleaseLoggerPlugin : LoggerPlugin<Unit> {
+
+    override val logger: Logger = Logger.ReleaseLogger
+    override val transform: TransformEventMessage<Unit> = transformEvent { }
+
+    override fun <E : Event> onEvent(dispatcher: String, event: E) {
+        // noop
+    }
+}
+
+

--- a/eiffel/src/main/java/com/etiennelenhart/eiffel/state/State.kt
+++ b/eiffel/src/main/java/com/etiennelenhart/eiffel/state/State.kt
@@ -1,5 +1,6 @@
 package com.etiennelenhart.eiffel.state
 
+import com.etiennelenhart.eiffel.Eiffel
 import com.etiennelenhart.eiffel.viewmodel.EiffelViewModel
 
 /**
@@ -8,5 +9,9 @@ import com.etiennelenhart.eiffel.viewmodel.EiffelViewModel
  * Only use `val`s and immutable data structures for properties and try
  * to avoid view specifics like resource IDs or data binding logic.
  * Implementing classes can be used as state in [EiffelViewModel].
+ *
+ * You may want to override the [toString] if you are using [Eiffel.debugMode] as the logger
+ * will convert the state to a string.  And if your [State] contains a large list of complex
+ * items, it may pollute the logcat.
  */
 interface State


### PR DESCRIPTION
## Proposal

Settle in, this is gonna be a long one.

Note: I will be providing samples in this PR, but there are more detailed comments in the code.

References #60 and replaces #68. 

I have added the ground work for a basic "Plugin" functionality for Eiffel.  Right now the only plugin I have created is a `LoggingPlugin` which will log `Event`'s to the logcat (more on that below).

### EiffelPlugin

Right now the `EiffelPlugin` interface is very basic.

```kotlin
interface EiffelPlugin {

    val name: String

    // dispatcher is just a tag for logging purposes
    fun <E : Event> onEvent(dispatcher: String, event: E)
}
```

The `name` property is currently unused, but my theory behind it was some way to identify the plugin, maybe for logging purposes.

The `onEvent` function is where the magic happens.  Each plugin will be able to react to every `Event` that is fired off by the `EiffelViewModel`.  This approach is very basic, and perhaps in the future we could add the ability to block or have some kind of "continuation" so the `EiffelPlugin` could observe the before/after of an event.

We may even want to pass along the `scope`, `dispatch` from the `EiffelViewModel` so that we can hijack the state/actions.  In my head I was thinking like a time-travel debugger of sorts.

The `dispatcher: String` is just a tag of the class that dispatched the action.  Perhaps a better approach would be to have `Event` contain the tag instead.

### Event

Right now there are a few supported events that can be fed to the plugins:

```kotlin
sealed class Event(val tag: String = "") {
  data class ViewModelCreated<S : State>(val name: String, val initialState: S) : Event()
  data class ViewModelCleared(val name: String) : Event()
  data class Message(val message: String) : Event("Message")
  data class Custom<T : Any>(val data: T) : Event()
  data class Action<A : StateAction>(val action: A) : Event("Action")
  data class Update<S : State>(val previous: S, val updated: S) : Event("Update")
  data class Interception<S : State, A : StateAction, I : StateInterception<S, A>>(
      val currentState: S,
      val action: A,
      val interception: I
  ) : Event("Interception")
}
```

Most of these are pretty self-explanatory, but if you need more info, again there are detailed comments in the code.

I am open to adding/removing/modifying these `Event`'s, this is just what I came up with for this PR.

### Dispatcher

The dispatcher controls the way the `Event`'s are dispatched to the plugins.  I have a basic implementation, but I'm not exactly in-love with it at its current state.  It feels dirty accessing the plugins via the global `Eiffel` but maybe its fine.  Again open to feedback/suggestion for it.

```kotlin
interface Dispatcher {
    fun <E : Event> dispatchEvent(dispatcher: String, event: E)

    object Default : Dispatcher {

        override fun <E : Event> dispatchEvent(dispatcher: String, event: E) {
            Eiffel.debugConfig.plugins.forEach { it.onEvent(dispatcher, event) }
        }
    }
}
```

### Packaged plugins

I have included a `LoggerPlugin` as a packaged plugin.  Right now it is **not** opt-in, and will always be added to the list of plugins.  It's also in the same package as `eiffel`, so we could even move it to it's own module.

I have created a `DefaultLoggerPlugin` and a `ReleaseLoggerPlugin`.  The latter is useful for production mode.  Say you override `EiffelViewModel.debug` to be `true`, and you forget to remove it before pushing the code out to production.  The release logger will take care of that by doing nothing when it's invoked. 

The `ReleaseLoggerPlugin` is opt-in and you can see an example of that in the sample app below.

```kotlin
interface LoggerPlugin<T> : EiffelPlugin {

    override val name: String
        get() = "Logger"

    val logger: Logger
    val transform: TransformEventMessage<T>
}
```

The `Logger` is the interface from the previous PR, just a way to customize how the event is logged.  In the sample app, I have it setup to use `Timber`.

The `transform` is where the magic happens.  Say you want to create a logger that can log to crashlytics, or some other custom solution.  Well with `transform` you can take the `Event` and transform it to any object you need.  There are of course some sensible defaults provided.

### Future plans

The whole reason why I decided to tackle a plugin approach was because of another library I saw called [Suas](https://suas.readme.io/).  I noticed they had a companion app for the desktop that would display all the store events.  So I looked into their source for both the android side, and the desktop side (they use TypeScript and Electron, both I've used extensively).  And it looks doable.  At least from the current standpoint of viewing the `State`, and `Action`'s.

You can see their monitor [here](https://suas.readme.io/docs/monitor-middleware-monitor-js)

So plugins I'm currently envisioning are:

- `eiffel-plugin-monitor`
   - With a desktop app for viewing the events
   - Using ADB or bonjour to communicate to the desktop app
   - Maybe use a JSON `LoggerPlugin`?
- `eiffel-plugin-logger-firebase`
   - A `LoggerPlugin` that logs certain `Event`'s to Firebase's Event's feature
   - Create a `Event.Error` that would log as a non-fatal error to crashlytics

### Sample app

It's not complete, but I have created a very basic sample app that showcases the new `EiffelPlugin` and `LoggerPlugin` features.  It's on a different branch and you can see it [here](https://github.com/jordond/Eiffel/tree/feature-add-sample-app/sample/src)

Notable points of interest are the `release/ReleaseApp.kt`, and `debug/DebugApp.kt`.  Then there is a basic `Fragment` and `EiffelViewModel`.

I will probably expand on it more later.

Here is an example of the log output:

![image](https://user-images.githubusercontent.com/528792/51949990-d5f75e00-23fc-11e9-9c37-ce6968895430.png)

It's marked as an error because in `DebugApp` I have overridden it to always log to `Timber.e` (for better visibility in the logcat)`.

## Closing

If you've made it this far congrats!  I know your busy, but I'd appreciate your feedback/criticism/ideas.  If we want to get logging in before we get the plugin architecture in, then I can extract it and create a new PR.