### PR TITLE
Modify Update to have the state as a reciever

### DIFF
--- a/eiffel/src/main/java/com/etiennelenhart/eiffel/state/Update.kt
+++ b/eiffel/src/main/java/com/etiennelenhart/eiffel/state/Update.kt
@@ -6,38 +6,58 @@ package com.etiennelenhart.eiffel.state
  * Example:
  *
  * ```
- * class SampleStateUpdate : Update<SampleState, SampleAction> {
+ * class SampleUpdate : Update<SampleState, SampleAction>() {
  *
- *     override fun invoke(state: SampleState, action: SampleAction) = when (action) {
- *         SampleAction.DoingSample -> state.copy(doing = "something")
- *         else -> state
- *     }
+ *    override fun SampleState.perform(action: SampleAction): SampleState = when (action) {
+ *        SampleAction.Loading -> copy(isLoading = true)
+ *        SampleAction.Loaded -> copy(isLoading = false, data = action.data)
+ *    }
  * }
  * ```
  *
  * @param[S] Type of [State] that can be updated.
  * @param[A] Type of supported [Action].
  */
-interface Update<S : State, A : Action> {
+abstract class Update<S : State, A : Action> {
 
     /**
-     * Update the provided [state] according to the given [action].
+     * Implementation for updating the state based on [action] scoped to the current state [S].
+     *
+     * @receiver[S] Current [State].
+     * @param[action] Dispatched [Action].
+     * @return The update [State]
+     */
+    abstract fun S.perform(action: A): S
+
+    /**
+     * Update the provided [state] using [perform] according to the given [action].
      *
      * @param[state] Current [State].
      * @param[action] Dispatched [Action].
      * @return The updated [State].
      */
-    operator fun invoke(state: S, action: A): S
+    operator fun invoke(state: S, action: A): S = state.perform(action)
 }
 
 /**
  * Convenience builder function that returns an object implementing [Update]. Passes provided lambda to overridden operator.
  *
- * @param[block] Lambda expression called with the current [State] and dispatched [Action]. Return the updated [State].
+ * Example:
+ *
+ * ```
+ * update<SampleState, SampleAction> {
+ *   when (action) {
+ *      is SampleAction.Loading -> copy(isLoading = true)
+ *      is SampleAction.Loaded -> copy(isLoading = false, data = action.data)
+ *   }
+ * }
+ * ```
+ *
+ * @param[perform] Lambda expression called scoped to the current [State] and dispatched [Action]. Return the updated [State].
  * @return An object implementing [Update].
  */
-fun <S : State, A : Action> update(block: (state: S, action: A) -> S): Update<S, A> {
-    return object : Update<S, A> {
-        override fun invoke(state: S, action: A) = block(state, action)
+fun <S : State, A : Action> update(perform: S.(action: A) -> S): Update<S, A> {
+    return object : Update<S, A>() {
+        override fun S.perform(action: A): S = perform(action)
     }
 }

--- a/eiffel/src/test/java/com/etiennelenhart/eiffel/viewmodel/EiffelViewModelTest.kt
+++ b/eiffel/src/test/java/com/etiennelenhart/eiffel/viewmodel/EiffelViewModelTest.kt
@@ -44,13 +44,12 @@ class EiffelViewModelTest {
         object Other : TestAction()
     }
 
-    val testStateUpdate = update<TestState, TestAction> { state, action ->
-        val count = state.count
+    val testStateUpdate = update<TestState, TestAction> { action ->
         when (action) {
-            TestAction.Increment -> state.copy(count = count + 1)
-            TestAction.Decrement -> state.copy(count = count - 1)
-            is TestAction.Add -> state.copy(count = count + action.amount)
-            TestAction.Other -> state.copy(other = "changed")
+            TestAction.Increment -> copy(count = count + 1)
+            TestAction.Decrement -> copy(count = count - 1)
+            is TestAction.Add -> copy(count = count + action.amount)
+            TestAction.Other -> copy(other = "changed")
         }
     }
 
@@ -58,7 +57,13 @@ class EiffelViewModelTest {
     fun `GIVEN EiffelViewModel subclass WHEN 'dispatch' called THEN 'action' is processed`() {
         @UseExperimental(ExperimentalCoroutinesApi::class)
         val viewModel =
-            object : EiffelViewModel<TestState, TestAction>(TestState(), testStateUpdate, emptyList(), Dispatchers.Unconfined, Dispatchers.Unconfined) {}
+            object : EiffelViewModel<TestState, TestAction>(
+                TestState(),
+                testStateUpdate,
+                emptyList(),
+                Dispatchers.Unconfined,
+                Dispatchers.Unconfined
+            ) {}
 
         var actual = 0
         viewModel.state.observeForever { actual = it.count }
@@ -71,7 +76,13 @@ class EiffelViewModelTest {
     fun `GIVEN EiffelViewModel subclass WHEN 'dispatch' called multiple times THEN all 'actions' are processed`() {
         @UseExperimental(ExperimentalCoroutinesApi::class)
         val viewModel =
-            object : EiffelViewModel<TestState, TestAction>(TestState(), testStateUpdate, emptyList(), Dispatchers.Unconfined, Dispatchers.Unconfined) {}
+            object : EiffelViewModel<TestState, TestAction>(
+                TestState(),
+                testStateUpdate,
+                emptyList(),
+                Dispatchers.Unconfined,
+                Dispatchers.Unconfined
+            ) {}
 
         var actual = 0
         viewModel.state.observeForever { actual = it.count }
@@ -93,7 +104,13 @@ class EiffelViewModelTest {
     fun `GIVEN EiffelViewModel subclass with a source 'LiveData' WHEN 'observeStateForever' called THEN updated state is emitted`() {
         @UseExperimental(ExperimentalCoroutinesApi::class)
         val viewModel =
-            object : EiffelViewModel<TestState, TestAction>(TestState(), testStateUpdate, emptyList(), Dispatchers.Unconfined, Dispatchers.Unconfined) {
+            object : EiffelViewModel<TestState, TestAction>(
+                TestState(),
+                testStateUpdate,
+                emptyList(),
+                Dispatchers.Unconfined,
+                Dispatchers.Unconfined
+            ) {
                 init {
                     addStateSource(OneLiveData()) { TestAction.Add(it) }
                 }
@@ -109,7 +126,13 @@ class EiffelViewModelTest {
     fun `GIVEN EiffelViewModel subclass with a removed source 'LiveData' WHEN 'observeStateForever' called THEN initial state is emitted`() {
         @UseExperimental(ExperimentalCoroutinesApi::class)
         val viewModel =
-            object : EiffelViewModel<TestState, TestAction>(TestState(), testStateUpdate, emptyList(), Dispatchers.Unconfined, Dispatchers.Unconfined) {
+            object : EiffelViewModel<TestState, TestAction>(
+                TestState(),
+                testStateUpdate,
+                emptyList(),
+                Dispatchers.Unconfined,
+                Dispatchers.Unconfined
+            ) {
                 init {
                     val source = OneLiveData()
                     addStateSource(source) { TestAction.Add(it) }
@@ -131,10 +154,11 @@ class EiffelViewModelTest {
         object Third : InterceptionAction()
     }
 
-    object InterceptionStateUpdate : Update<InterceptionState, InterceptionAction> {
-        override fun invoke(state: InterceptionState, action: InterceptionAction) = when (action) {
-            InterceptionAction.Third -> state.copy(correct = true)
-            else -> state
+    object InterceptionStateUpdate : Update<InterceptionState, InterceptionAction>() {
+
+        override fun InterceptionState.perform(action: InterceptionAction) = when (action) {
+            InterceptionAction.Third -> copy(correct = true)
+            else -> this
         }
     }
 

--- a/eiffel/src/test/java/com/etiennelenhart/eiffel/viewmodel/EiffelViewModelTest.kt
+++ b/eiffel/src/test/java/com/etiennelenhart/eiffel/viewmodel/EiffelViewModelTest.kt
@@ -57,13 +57,7 @@ class EiffelViewModelTest {
     fun `GIVEN EiffelViewModel subclass WHEN 'dispatch' called THEN 'action' is processed`() {
         @UseExperimental(ExperimentalCoroutinesApi::class)
         val viewModel =
-            object : EiffelViewModel<TestState, TestAction>(
-                TestState(),
-                testStateUpdate,
-                emptyList(),
-                Dispatchers.Unconfined,
-                Dispatchers.Unconfined
-            ) {}
+            object : EiffelViewModel<TestState, TestAction>(TestState(), testStateUpdate, emptyList(), Dispatchers.Unconfined, Dispatchers.Unconfined) {}
 
         var actual = 0
         viewModel.state.observeForever { actual = it.count }
@@ -76,13 +70,7 @@ class EiffelViewModelTest {
     fun `GIVEN EiffelViewModel subclass WHEN 'dispatch' called multiple times THEN all 'actions' are processed`() {
         @UseExperimental(ExperimentalCoroutinesApi::class)
         val viewModel =
-            object : EiffelViewModel<TestState, TestAction>(
-                TestState(),
-                testStateUpdate,
-                emptyList(),
-                Dispatchers.Unconfined,
-                Dispatchers.Unconfined
-            ) {}
+            object : EiffelViewModel<TestState, TestAction>(TestState(), testStateUpdate, emptyList(), Dispatchers.Unconfined, Dispatchers.Unconfined) {}
 
         var actual = 0
         viewModel.state.observeForever { actual = it.count }
@@ -104,13 +92,7 @@ class EiffelViewModelTest {
     fun `GIVEN EiffelViewModel subclass with a source 'LiveData' WHEN 'observeStateForever' called THEN updated state is emitted`() {
         @UseExperimental(ExperimentalCoroutinesApi::class)
         val viewModel =
-            object : EiffelViewModel<TestState, TestAction>(
-                TestState(),
-                testStateUpdate,
-                emptyList(),
-                Dispatchers.Unconfined,
-                Dispatchers.Unconfined
-            ) {
+            object : EiffelViewModel<TestState, TestAction>(TestState(), testStateUpdate, emptyList(), Dispatchers.Unconfined, Dispatchers.Unconfined) {
                 init {
                     addStateSource(OneLiveData()) { TestAction.Add(it) }
                 }
@@ -126,13 +108,7 @@ class EiffelViewModelTest {
     fun `GIVEN EiffelViewModel subclass with a removed source 'LiveData' WHEN 'observeStateForever' called THEN initial state is emitted`() {
         @UseExperimental(ExperimentalCoroutinesApi::class)
         val viewModel =
-            object : EiffelViewModel<TestState, TestAction>(
-                TestState(),
-                testStateUpdate,
-                emptyList(),
-                Dispatchers.Unconfined,
-                Dispatchers.Unconfined
-            ) {
+            object : EiffelViewModel<TestState, TestAction>(TestState(), testStateUpdate, emptyList(), Dispatchers.Unconfined, Dispatchers.Unconfined) {
                 init {
                     val source = OneLiveData()
                     addStateSource(source) { TestAction.Add(it) }
@@ -197,13 +173,7 @@ class EiffelViewModelTest {
     @Test
     fun `GIVEN EiffelViewModel subclass with interceptions WHEN 'dispatch' called THEN all interceptions are applied`() {
         @UseExperimental(ExperimentalCoroutinesApi::class)
-        val viewModel = object : EiffelViewModel<InterceptionState, InterceptionAction>(
-            InterceptionState(),
-            InterceptionStateUpdate,
-            listOf(firstInterception, secondInterception),
-            Dispatchers.Unconfined,
-            Dispatchers.Unconfined
-        ) {}
+        val viewModel = object : EiffelViewModel<InterceptionState, InterceptionAction>(InterceptionState(), InterceptionStateUpdate, listOf(firstInterception, secondInterception), Dispatchers.Unconfined, Dispatchers.Unconfined) {}
 
         var actual = false
         viewModel.state.observeForever { actual = it.correct }

--- a/eiffel/src/test/java/com/etiennelenhart/eiffel/viewmodel/EiffelViewModelTest.kt
+++ b/eiffel/src/test/java/com/etiennelenhart/eiffel/viewmodel/EiffelViewModelTest.kt
@@ -173,7 +173,13 @@ class EiffelViewModelTest {
     @Test
     fun `GIVEN EiffelViewModel subclass with interceptions WHEN 'dispatch' called THEN all interceptions are applied`() {
         @UseExperimental(ExperimentalCoroutinesApi::class)
-        val viewModel = object : EiffelViewModel<InterceptionState, InterceptionAction>(InterceptionState(), InterceptionStateUpdate, listOf(firstInterception, secondInterception), Dispatchers.Unconfined, Dispatchers.Unconfined) {}
+        val viewModel = object : EiffelViewModel<InterceptionState, InterceptionAction>(
+            InterceptionState(),
+            InterceptionStateUpdate,
+            listOf(firstInterception, secondInterception),
+            Dispatchers.Unconfined,
+            Dispatchers.Unconfined
+        ) {}
 
         var actual = false
         viewModel.state.observeForever { actual = it.correct }


### PR DESCRIPTION
Closes #73 

- Modify the `Update` interface to an `abstract class` that contains a function for updating the state which uses the state as the receiver.
- Modify the `update()` function to support the new receiver logic.
- Update tests to match new functionality.