### PR TITLE
Fix multi-line log output

### DIFF
--- a/eiffel/src/main/java/com/etiennelenhart/eiffel/viewmodel/EiffelViewModel.kt
+++ b/eiffel/src/main/java/com/etiennelenhart/eiffel/viewmodel/EiffelViewModel.kt
@@ -69,12 +69,8 @@ abstract class EiffelViewModel<S : State, A : Action>(
         channel.consumeEach { action ->
             val currentState = _state.value!!
 
-            log(
-                """
-                ┌───── ↘ Processing: $action
-                ├─ ↓ Current state: $currentState
-                """.trimIndent()
-            )
+            log("┌───── ↘ Processing: $action")
+            log("├─ ↓ Current state: $currentState")
 
             val resultingAction = applyInterceptions(currentState, action)
 
@@ -112,12 +108,8 @@ abstract class EiffelViewModel<S : State, A : Action>(
         { scope, state, action, dispatch ->
             interceptions[index].run {
                 if (index > 0) log("├─   ← Forwarded:    $action")
-                log(
-                    """
-                    ├─ ↓ Interception:  ${this::class.java.simpleName}
-                    ├─   → Received:     $action
-                    """.trimIndent()
-                )
+                log("├─ ↓ Interception:  ${this::class.java.simpleName}")
+                log("├─   → Received:     $action")
                 invoke(scope, state, action, dispatch, next(index + 1))
             }
         }


### PR DESCRIPTION
One thing I didn't catch with PR #72 is the log output can be wonky because of the use of multi-line kotlin string literals.

Before: (I added a dummy interception to showcase the indent problem)

![image](https://user-images.githubusercontent.com/528792/52497986-886db480-2ba5-11e9-9878-bbe051cbe621.png)


After:

![image](https://user-images.githubusercontent.com/528792/52497751-e4840900-2ba4-11e9-975f-34375836c39a.png)

So I have replaced all the multi-line strings with calls to the log function.