### PR TITLE
Add 'Interceptions' class with Builder

### DIFF
--- a/eiffel/src/main/java/com/etiennelenhart/eiffel/interception/Adapter.kt
+++ b/eiffel/src/main/java/com/etiennelenhart/eiffel/interception/Adapter.kt
@@ -9,39 +9,14 @@ import kotlinx.coroutines.CoroutineScope
  *
  * @param[S] Type of [State] to receive.
  * @param[A] Type of supported [Action].
- */
-abstract class Adapter<S : State, A : Action> : Interception<S, A> {
-
-    /**
-     * Adapts the given [action] to a new one.
-     *
-     * @param[state] Current [State].
-     * @param[action] Received [Action].
-     * @return The adapted [Action].
-     */
-    protected abstract fun adapt(state: S, action: A): A
-
-    final override suspend fun invoke(scope: CoroutineScope, state: S, action: A, dispatch: (action: A) -> Unit, next: Next<S, A>): A? {
-        return next(scope, state, adapt(state, action), dispatch)
-    }
-}
-
-/**
- * Convenience builder function that returns an object extending [Adapter]. Passes provided lambda to overridden function.
- *
- * @param[S] Type of [State] to receive.
- * @param[A] Type of supported [Action].
  * @param[debugName] Custom name to use when logging the [Adapter] in debug mode.
  * @param[adapt] Lambda expression called with the current [State] and received [Action]. May adapt the action to a new one.
- * @return An object extending [Adapter].
  */
-fun <S : State, A : Action> adapter(
-    debugName: String = "",
-    adapt: (state: S, action: A) -> A
-): Adapter<S, A> {
-    return object : Adapter<S, A>() {
-        override val debugName: String = debugName.ifEmpty { toString() }
+class Adapter<S : State, A : Action>(debugName: String = "", private val adapt: (state: S, action: A) -> A) : Interception<S, A> {
 
-        override fun adapt(state: S, action: A) = adapt(state, action)
+    override val debugName = debugName.ifEmpty { toString() }
+
+    override suspend fun invoke(scope: CoroutineScope, state: S, action: A, dispatch: (action: A) -> Unit, next: Next<S, A>): A? {
+        return next(scope, state, adapt(state, action), dispatch)
     }
 }

--- a/eiffel/src/main/java/com/etiennelenhart/eiffel/interception/Filter.kt
+++ b/eiffel/src/main/java/com/etiennelenhart/eiffel/interception/Filter.kt
@@ -9,40 +9,15 @@ import kotlinx.coroutines.CoroutineScope
  *
  * @param[S] Type of [State] to receive.
  * @param[A] Type of supported [Action].
- */
-abstract class Filter<S : State, A : Action> : Interception<S, A> {
-
-    /**
-     * Decides whether the received [action] should be forwarded.
-     *
-     * @param[state] Current [State].
-     * @param[action] Received [Action].
-     * @return `true` if received [action] should be forwarded, `false` otherwise.
-     */
-    protected abstract fun predicate(state: S, action: A): Boolean
-
-    final override suspend fun invoke(scope: CoroutineScope, state: S, action: A, dispatch: (A) -> Unit, next: Next<S, A>): A? {
-        return if (predicate(state, action)) next(scope, state, action, dispatch) else null
-    }
-}
-
-/**
- * Convenience builder function that returns an object extending [Filter]. Passes provided lambda to overridden function.
- *
- * @param[S] Type of [State] to receive.
- * @param[A] Type of supported [Action].
  * @param[debugName] Custom name to use when logging the [Filter] in debug mode.
  * @param[predicate] Lambda expression called with the current [State] and received [Action]. Return `true` if received [Action] should be forwarded,
  * `false` otherwise.
- * @return An object extending [Filter].
  */
-fun <S : State, A : Action> filter(
-    debugName: String = "",
-    predicate: (state: S, action: A) -> Boolean
-): Filter<S, A> {
-    return object : Filter<S, A>() {
-        override val debugName: String = debugName.ifEmpty { toString() }
+class Filter<S : State, A : Action>(debugName: String = "", private val predicate: (state: S, action: A) -> Boolean) : Interception<S, A> {
 
-        override fun predicate(state: S, action: A) = predicate(state, action)
+    override val debugName: String = debugName.ifEmpty { toString() }
+
+    override suspend fun invoke(scope: CoroutineScope, state: S, action: A, dispatch: (A) -> Unit, next: Next<S, A>): A? {
+        return if (predicate(state, action)) next(scope, state, action, dispatch) else null
     }
 }

--- a/eiffel/src/main/java/com/etiennelenhart/eiffel/interception/Interceptions.kt
+++ b/eiffel/src/main/java/com/etiennelenhart/eiffel/interception/Interceptions.kt
@@ -1,0 +1,244 @@
+package com.etiennelenhart.eiffel.interception
+
+import com.etiennelenhart.eiffel.interception.command.*
+import com.etiennelenhart.eiffel.state.Action
+import com.etiennelenhart.eiffel.state.State
+import com.etiennelenhart.eiffel.viewmodel.EiffelViewModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.ReceiveChannel
+
+@DslMarker
+annotation class InterceptionsBuilderMarker
+
+/**
+ * A chain of [Interception] instances to use for [EiffelViewModel.interceptions].
+ *
+ * See [interceptions] or [Interceptions.Builder] for a more convenient way to build the chain.
+ *
+ * @param[S] Type of [State] to receive.
+ * @param[A] Type of supported [Action].
+ * @param[chain] List of [Interception] instances.
+ */
+class Interceptions<S : State, A : Action>(chain: List<Interception<S, A>>) : List<Interception<S, A>> by chain {
+
+    constructor(vararg items: Interception<S, A>) : this(items.toList())
+
+    /**
+     * Builder class for [Interceptions].
+     *
+     * Example:
+     * ```
+     * Interceptions.Builder<SampleState, SampleAction>()
+     *     .add(CustomInterception())
+     *     .add(targetedInterceptions)
+     *     .adapter { state, action -> if (state.that && action is SampleAction.DoSomething) SampleAction.DoThat else action }
+     *     .filter { _, action -> action !is SampleAction.IgnoreMe }
+     *     .pipe { _, action -> Log.d("Sample", "Chain result: $action") }
+     *     .build()
+     * ```
+     */
+    @InterceptionsBuilderMarker
+    class Builder<S : State, A : Action> {
+
+        private val chain = mutableListOf<Interception<S, A>>()
+
+        /**
+         * Adds the given [interceptions] to the chain.
+         */
+        fun add(vararg interceptions: Interception<S, A>) = add(interceptions.toList())
+
+        /**
+         * Adds the given [interceptions] to the chain.
+         */
+        fun add(interceptions: List<Interception<S, A>>) = apply { chain.addAll(interceptions) }
+
+        /**
+         * Creates an [Adapter] and adds it to the chain.
+         */
+        fun adapter(debugName: String = "", adapt: (state: S, action: A) -> A) = add(Adapter(debugName, adapt))
+
+        /**
+         * Creates a [Filter] and adds it to the chain.
+         */
+        fun filter(debugName: String = "", predicate: (state: S, action: A) -> Boolean) = add(Filter(debugName, predicate))
+
+        /**
+         * Creates a [Pipe] and adds it to the chain.
+         */
+        fun pipe(debugName: String = "", before: (state: S, action: A) -> Unit = { _, _ -> }, after: (state: S, action: A?) -> Unit = { _, _ -> }) =
+            add(Pipe(debugName, before, after))
+
+        /**
+         * Creates a [Command] and adds it to the chain.
+         */
+        fun command(debugName: String = "", react: ReactionScope.(action: A) -> Reaction<S, A>) = add(Command(debugName, react))
+
+        /**
+         * Creates a [LiveCommand] and adds it to the chain.
+         */
+        fun liveCommand(debugName: String = "", react: LiveReactionScope.(action: A) -> LiveReaction<S, A>) = add(LiveCommand(debugName, react))
+
+        /**
+         * Builds an [Interceptions] instance with the created chain.
+         */
+        fun build() = Interceptions(*chain.toTypedArray())
+
+        /**
+         * Convenience wrapper around [Interceptions.Builder.Targeted].
+         *
+         * Example:
+         * ```
+         * interceptions<SampleState, SampleAction> {
+         *     on<SampleAction.DoSomething> {
+         *         adapter { state, action -> if (state.that) SampleAction.DoThat else action }
+         *         filter { state, _ -> !state.doingSomething }
+         *         pipe { _, _ -> Log.d("Sample", "SampleAction.DoSomething dispatched") }
+         *     }
+         * }
+         * ```
+         */
+        inline fun <reified T : A> on(build: Interceptions.Builder.Targeted<S, A, T>.() -> Unit) =
+            Interceptions.Builder.Targeted<S, A, T>(target = { it is T }).apply(build).build()
+
+        /**
+         * Builder class for a list of [Interception] instances targeted to a specific action.
+         *
+         * Example:
+         * ```
+         * Interceptions.Builder.Targeted<SampleState, SampleAction, SampleAction.DoSomething>(target = { it is SampleAction.DoSomething })
+         *     .adapter { state, action -> if (state.that) SampleAction.DoThat else action }
+         *     .filter { state, _ -> !state.doingSomething }
+         *     .pipe { _, _ -> Log.d("Sample", "SampleAction.DoSomething dispatched") }
+         *     .build()
+         * ```
+         *
+         * @param[T] Type of the targeted action.
+         * @param[target] Lambda expression to determine the target depending on the given `action`. Should return `true` if it matches the target,
+         * otherwise `false`.
+         */
+        @Suppress("UNCHECKED_CAST")
+        @InterceptionsBuilderMarker
+        class Targeted<S : State, A : Action, T : A>(private val target: (action: A?) -> Boolean) {
+
+            private val chain = mutableListOf<Interception<S, A>>()
+
+            /**
+             * Creates an [Adapter] that only calls [adapt] for the targeted action.
+             *
+             * *Note: `action` in [adapt] is already cast to [T].*
+             */
+            fun adapter(debugName: String = "", adapt: (state: S, action: T) -> A) = apply {
+                chain.add(Adapter(debugName) { state, action -> if (target(action)) adapt(state, action as T) else action })
+            }
+
+            /**
+             * Creates a [Filter] that only calls [predicate] for the targeted action.
+             *
+             * *Note: `action` in [predicate] is already cast to [T].*
+             */
+            fun filter(debugName: String = "", predicate: (state: S, action: T) -> Boolean) = apply {
+                chain.add(Filter(debugName) { state, action -> if (target(action)) predicate(state, action as T) else true })
+            }
+
+            /**
+             * Creates a [Pipe] that only calls [before] and [after] for the targeted action.
+             *
+             * *Note: `action` in [before] and [after] is already cast to [T].*
+             */
+            fun pipe(debugName: String = "", before: (state: S, action: T) -> Unit = { _, _ -> }, after: (state: S, action: A?) -> Unit) = apply {
+                chain.add(
+                    Pipe(
+                        debugName,
+                        { state, action -> if (target(action)) before(state, action as T) },
+                        { state, action -> if (target(action)) after(state, action as T) }
+                    )
+                )
+            }
+
+            /**
+             * Creates a consuming [Command] that only calls [block] for the targeted action.
+             *
+             * *Note: [block] is additionally called with targeted `action`.*
+             *
+             * @see[Reaction.Consuming]
+             */
+            fun consumingCommand(debugName: String = "", immediateAction: A, block: suspend (state: S, action: T, dispatch: (A) -> Unit) -> Unit) = apply {
+                chain.add(
+                    Command(debugName) { action ->
+                        if (target(action)) consuming(immediateAction) { state, dispatch -> block(state, action as T, dispatch) } else ignoring()
+                    }
+                )
+            }
+
+            /**
+             * Creates a forwarding [Command] that only calls [block] for the targeted action.
+             *
+             * *Note: [block] is additionally called with targeted `action`.*
+             *
+             * @see[Reaction.Forwarding]
+             */
+            fun forwardingCommand(debugName: String = "", block: suspend (state: S, action: T, dispatch: (A) -> Unit) -> Unit) = apply {
+                chain.add(
+                    Command(debugName) { action ->
+                        if (target(action)) forwarding { state, dispatch -> block(state, action as T, dispatch) } else ignoring()
+                    }
+                )
+            }
+
+            /**
+             * Creates a consuming [LiveCommand] that only calls [block] for the targeted action.
+             *
+             * *Note: [block] is additionally called with targeted `action`.*
+             *
+             * @see[LiveReaction.Consuming]
+             */
+            fun consumingLiveCommand(
+                debugName: String = "",
+                immediateAction: A,
+                block: suspend CoroutineScope.(state: S, action: T) -> ReceiveChannel<A>
+            ) = apply {
+                chain.add(
+                    LiveCommand(debugName) { action ->
+                        if (target(action)) consuming(immediateAction) { state -> block(state, action as T) } else ignoring()
+                    }
+                )
+            }
+
+            /**
+             * Creates a forwarding [LiveCommand] that only calls [block] for the targeted action.
+             *
+             * *Note: [block] is additionally called with targeted `action`.*
+             *
+             * @see[LiveReaction.Forwarding]
+             */
+            fun forwardingLiveCommand(debugName: String = "", block: suspend CoroutineScope.(state: S, action: T) -> ReceiveChannel<A>) = apply {
+                chain.add(
+                    LiveCommand(debugName) { action ->
+                        if (target(action)) forwarding { state -> block(state, action as T) } else ignoring()
+                    }
+                )
+            }
+
+            /**
+             * Builds a list of targeted [Interception] instances.
+             */
+            fun build(): List<Interception<S, A>> = chain
+        }
+    }
+}
+
+/**
+ * Convenience wrapper around [Interceptions.Builder].
+ *
+ * Example:
+ * ```
+ * interceptions<SampleState, SampleAction> {
+ *     add(CustomInterception())
+ *     add(targetedInterceptions)
+ *     adapter { state, action -> if (state.that && action is SampleAction.DoSomething) SampleAction.DoThat else action }
+ *     filter { _, action -> action !is SampleAction.IgnoreMe }
+ *     pipe { _, action -> Log.d("Sample", "Chain result: $action") }
+ * }
+ * ```
+ */
+inline fun <S : State, A : Action> interceptions(build: Interceptions.Builder<S, A>.() -> Unit) = Interceptions.Builder<S, A>().apply(build).build()

--- a/eiffel/src/main/java/com/etiennelenhart/eiffel/interception/Pipe.kt
+++ b/eiffel/src/main/java/com/etiennelenhart/eiffel/interception/Pipe.kt
@@ -10,47 +10,22 @@ import kotlinx.coroutines.CoroutineScope
  *
  * @param[S] Type of [State] to receive.
  * @param[A] Type of supported [Action].
+ * @param[debugName] Custom name to use when logging the [Pipe] in debug mode.
+ * @param[before] Lambda expression called with the current [State] and received [Action].
+ * @param[after] Lambda expression called with the current [State] and updated [Action] from next item. Might be 'null' if blocked by a [Filter].
  */
-abstract class Pipe<S : State, A : Action> : Interception<S, A> {
+class Pipe<S : State, A : Action>(
+    debugName: String = "",
+    private val before: (state: S, action: A) -> Unit = { _, _ -> },
+    private val after: (state: S, action: A?) -> Unit = { _, _ -> }
+) : Interception<S, A> {
 
-    /**
-     * Called with the current [State] and received [Action].
-     */
-    protected abstract fun before(state: S, action: A)
+    override val debugName: String = debugName.ifEmpty { toString() }
 
-    /**
-     * Called with the current [State] and updated [Action] from next items. Might be 'null' if blocked by a following [Filter].
-     */
-    protected abstract fun after(state: S, action: A?)
-
-    final override suspend fun invoke(scope: CoroutineScope, state: S, action: A, dispatch: (A) -> Unit, next: Next<S, A>): A? {
+    override suspend fun invoke(scope: CoroutineScope, state: S, action: A, dispatch: (A) -> Unit, next: Next<S, A>): A? {
         before(state, action)
         val newAction = next(scope, state, action, dispatch)
         after(state, newAction)
         return newAction
-    }
-}
-
-/**
- * Convenience builder function that returns an object extending [Pipe]. Passes provided lambdas to overridden functions.
- *
- * @param[S] Type of [State] to receive.
- * @param[A] Type of supported [Action].
- * @param[debugName] Custom name to use when logging the [Pipe] in debug mode.
- * @param[before] Lambda expression called with the current [State] and received [Action].
- * @param[after] Lambda expression called with the current [State] and updated [Action] from next item. Might be 'null' if blocked by a following [Filter].
- * @return An object extending [Pipe].
- */
-fun <S : State, A : Action> pipe(
-    debugName: String = "",
-    before: (state: S, action: A) -> Unit = { _, _ -> },
-    after: (state: S, action: A?) -> Unit = { _, _ -> }
-): Pipe<S, A> {
-    return object : Pipe<S, A>() {
-        override val debugName: String = debugName.ifEmpty { toString() }
-
-        override fun before(state: S, action: A) = before(state, action)
-
-        override fun after(state: S, action: A?) = after(state, action)
     }
 }

--- a/eiffel/src/main/java/com/etiennelenhart/eiffel/interception/command/Command.kt
+++ b/eiffel/src/main/java/com/etiennelenhart/eiffel/interception/command/Command.kt
@@ -8,36 +8,30 @@ import com.etiennelenhart.eiffel.viewmodel.EiffelViewModel
 import kotlinx.coroutines.*
 
 /**
- * [Interception] that may react to a received [Action] by either ignoring it or consuming it and executing an asynchronous side effect.
- * If consuming provide [Reaction.Consuming] with an `immediateAction` that is immediately returned to not interrupt state updating and a suspending
- * `block`. When the `block` is done call `dispatch` which will dispatch the provided [Action] using [EiffelViewModel.dispatch], effectively
- * invoking the [EiffelViewModel.interceptions] chain again.
+ * [Interception] that may react to a received [Action] by either ignoring it or consuming/forwarding it and executing an asynchronous side effect.
  *
- * *Note: The suspending block is scoped to the corresponding [EiffelViewModel]'s lifecycle.*
+ * The [react] block may return one of the following:
+ * * [Reaction.Ignoring] - Simply forwards the `action`.
+ * * [Reaction.Consuming] - Immediately returns its `immediateAction` and passes the `action` to its suspending `block`.
+ * * [Reaction.Forwarding] - Similar to `Consuming` but forwards the `action` instead of returning it.
+ *
+ * The suspending `block` is called asynchronously and not awaited. To update state from the `block` call the provided `dispatch` lambda expression.
+ * The block is scoped to the corresponding [EiffelViewModel]'s [CoroutineScope], so it will be cancelled when [EiffelViewModel.onCleared] is called
+ * during execution. Since cancellation is cooperative with coroutines, if the side effect wants to support it either use a [coroutineScope] builder
+ * and check for [isActive] or use [yield].
  *
  * @param[S] Type of [State] to receive.
  * @param[A] Type of supported [Action].
+ * @param[debugName] Custom name to use when logging the [Command] in debug mode.
+ * @param[react] Lambda expression called with the received [Action]. Use either [ReactionScope.consuming], [ReactionScope.forwarding]
+ * or [ReactionScope.ignoring].
  */
-abstract class Command<S : State, A : Action> : Interception<S, A> {
+class Command<S : State, A : Action>(debugName: String = "", private val react: ReactionScope.(action: A) -> Reaction<S, A>) : Interception<S, A> {
 
-    /**
-     * Return one of the following:
-     * * [Reaction.Ignoring] - Simply forwards the [action].
-     * * [Reaction.Consuming] - Immediately returns its `immediateAction` and passes the [action] to its suspending `block`.
-     * * [Reaction.Forwarding] - Similar to `Consuming` but forwards the [action] instead of returning.
-     *
-     * The suspending `block` is called asynchronously and not awaited. To update state from the `block` call the provided `dispatch` lambda expression.
-     * The block is scoped to the corresponding [EiffelViewModel]'s [CoroutineScope], so it will be cancelled when [EiffelViewModel.onCleared] is called
-     * during execution. Since cancellation is cooperative with coroutines, if the side effect wants to support it either use a [coroutineScope] builder
-     * and check for [isActive] or use [yield].
-     *
-     * @param[action] The received [Action].
-     * @return One of [Reaction.Consuming], [Reaction.Forwarding] or [Reaction.Ignoring].
-     */
-    protected abstract fun react(action: A): Reaction<S, A>
+    override val debugName: String = debugName.ifEmpty { toString() }
 
-    final override suspend fun invoke(scope: CoroutineScope, state: S, action: A, dispatch: (A) -> Unit, next: Next<S, A>): A? {
-        return when (val reaction = react(action)) {
+    override suspend fun invoke(scope: CoroutineScope, state: S, action: A, dispatch: (A) -> Unit, next: Next<S, A>): A? {
+        return when (val reaction = ReactionScope.react(action)) {
             is Reaction.Consuming -> {
                 scope.launch { reaction.block(state, dispatch) }
                 reaction.immediateAction
@@ -48,26 +42,5 @@ abstract class Command<S : State, A : Action> : Interception<S, A> {
             }
             is Reaction.Ignoring -> next(scope, state, action, dispatch)
         }
-    }
-}
-
-/**
- * Convenience builder function that returns an object extending [Command]. Passes provided lambda to overridden function.
- *
- * @param[S] Type of [State] to receive.
- * @param[A] Type of supported [Action].
- * @param[debugName] Custom name to use when logging the [Command] in debug mode.
- * @param[react] Lambda expression called with the received [Action]. Use one of [ReactionScope.consuming], [ReactionScope.forwarding]
- * or [ReactionScope.ignoring]. (see [Command.react])
- * @return An object extending [Command].
- */
-fun <S : State, A : Action> command(
-    debugName: String = "",
-    react: ReactionScope.(action: A) -> Reaction<S, A>
-): Command<S, A> {
-    return object : Command<S, A>() {
-        override val debugName: String = debugName.ifEmpty { toString() }
-
-        override fun react(action: A) = ReactionScope.react(action)
     }
 }

--- a/eiffel/src/main/java/com/etiennelenhart/eiffel/interception/command/LiveCommand.kt
+++ b/eiffel/src/main/java/com/etiennelenhart/eiffel/interception/command/LiveCommand.kt
@@ -14,37 +14,32 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
 /**
- * [Interception] that may react to a received [Action] by either ignoring it or consuming it and executing an asynchronous side effect with continuous
- * updates. If consuming provide [LiveReaction.Consuming] with an `immediateAction` that is immediately returned to not interrupt state updating and a
- * suspending `block` returning a [Channel]. In the `block` call [Channel.send] which will dispatch the provided [Action] using [EiffelViewModel.dispatch],
- * effectively invoking the [EiffelViewModel.interceptions] chain again.
+ * [Interception] that may react to a received [Action] by either ignoring it or consuming/forwarding it and executing an asynchronous side effect with
+ * continuous updates.
  *
- * *Note: The suspending block is scoped to the corresponding [EiffelViewModel]'s lifecycle.*
+ * The [react] block may return one of the following:
+ * * [Reaction.Ignoring] - Simply forwards the `action`.
+ * * [Reaction.Consuming] - Immediately returns its `immediateAction` and passes the `action` to its suspending `block`.
+ * * [Reaction.Forwarding] - Similar to `Consuming` but forwards the `action` instead of returning.
+ *
+ * The suspending `block` is called asynchronously and the returned channel is subscribed to. To update state from the `block` call [Channel.send]
+ * on the returned channel. The block is scoped to the corresponding [EiffelViewModel]'s [CoroutineScope], so it will be cancelled when
+ * [EiffelViewModel.onCleared] is called during execution. Since cancellation is cooperative with coroutines, if the side effect wants to support
+ * it the easiest way is to use [produce] builder and check for [isActive].
  *
  * @param[S] Type of [State] to receive.
  * @param[A] Type of supported [Action].
+ * @param[debugName] Custom name to use when logging the [LiveCommand] in debug mode.
+ * @param[react] Lambda expression called with the received [Action]. Use one of [LiveReactionScope.consuming], [LiveReactionScope.forwarding]
+ * or [LiveReactionScope.ignoring].
  */
-abstract class LiveCommand<S : State, A : Action> : Interception<S, A> {
+class LiveCommand<S : State, A : Action>(debugName: String = "", private val react: LiveReactionScope.(action: A) -> LiveReaction<S, A>) : Interception<S, A> {
 
-    /**
-     * Return one of the following:
-     * * [Reaction.Ignoring] - Simply forwards the [action].
-     * * [Reaction.Consuming] - Immediately returns its `immediateAction` and passes the [action] to its suspending `block`.
-     * * [Reaction.Forwarding] - Similar to `Consuming` but forwards the [action] instead of returning.
-     *
-     * The suspending `block` is called asynchronously and the returned channel is subscribed to. To update state from the `block` call [Channel.send]
-     * on the returned channel. The block is scoped to the corresponding [EiffelViewModel]'s [CoroutineScope], so it will be cancelled when
-     * [EiffelViewModel.onCleared] is called during execution. Since cancellation is cooperative with coroutines, if the side effect wants to support
-     * it the easiest way is to use [produce] builder and check for [isActive].
-     *
-     * @param[action] The received [Action].
-     * @return Either [LiveReaction.Consuming] or [LiveReaction.Ignoring].
-     */
-    protected abstract fun react(action: A): LiveReaction<S, A>
+    override val debugName: String = debugName.ifEmpty { toString() }
 
     @UseExperimental(ObsoleteCoroutinesApi::class)
-    final override suspend fun invoke(scope: CoroutineScope, state: S, action: A, dispatch: (action: A) -> Unit, next: Next<S, A>): A? {
-        return when (val reaction = react(action)) {
+    override suspend fun invoke(scope: CoroutineScope, state: S, action: A, dispatch: (action: A) -> Unit, next: Next<S, A>): A? {
+        return when (val reaction = LiveReactionScope.react(action)) {
             is LiveReaction.Consuming -> {
                 scope.launch {
                     val channel = reaction.block(scope, state)
@@ -61,28 +56,5 @@ abstract class LiveCommand<S : State, A : Action> : Interception<S, A> {
             }
             is LiveReaction.Ignoring -> next(scope, state, action, dispatch)
         }
-    }
-}
-
-/**
- * /**
- * Convenience builder function that returns an object extending [LiveCommand]. Passes provided lambda to overridden function.
- *
- * @param[S] Type of [State] to receive.
- * @param[A] Type of supported [Action].
- * @param[debugName] Custom name to use when logging the [LiveCommand] in debug mode.
- * @param[react] Lambda expression called with the received [Action]. Use one of [LiveReactionScope.consuming], [LiveReactionScope.forwarding]
- * or [LiveReactionScope.ignoring]. (see [LiveCommand.react])
- * @return An object extending [LiveCommand].
-*/
- */
-fun <S : State, A : Action> liveCommand(
-    debugName: String = "",
-    react: LiveReactionScope.(action: A) -> LiveReaction<S, A>
-): LiveCommand<S, A> {
-    return object : LiveCommand<S, A>() {
-        override val debugName: String = debugName.ifEmpty { toString() }
-
-        override fun react(action: A) = LiveReactionScope.react(action)
     }
 }

--- a/eiffel/src/main/java/com/etiennelenhart/eiffel/viewmodel/EiffelViewModel.kt
+++ b/eiffel/src/main/java/com/etiennelenhart/eiffel/viewmodel/EiffelViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.ViewModel
 import com.etiennelenhart.eiffel.Eiffel
 import com.etiennelenhart.eiffel.interception.Interception
+import com.etiennelenhart.eiffel.interception.Interceptions
 import com.etiennelenhart.eiffel.interception.Next
 import com.etiennelenhart.eiffel.state.Action
 import com.etiennelenhart.eiffel.state.State
@@ -30,10 +31,7 @@ import kotlinx.coroutines.channels.consumeEach
  * @param[A] Type of supported [Action]s.
  * @param[initialState] Initial state to set when view model is created.
  */
-abstract class EiffelViewModel<S : State, A : Action> internal constructor(
-    initialState: S,
-    actionDispatcher: CoroutineDispatcher
-) : ViewModel() {
+abstract class EiffelViewModel<S : State, A : Action> internal constructor(initialState: S, actionDispatcher: CoroutineDispatcher) : ViewModel() {
 
     /**
      * Used to update the state according to an action.
@@ -43,7 +41,7 @@ abstract class EiffelViewModel<S : State, A : Action> internal constructor(
     /**
      * Chain of [Interception] objects to apply to a dispatched [Action].
      */
-    protected open val interceptions: List<Interception<S, A>> = emptyList()
+    protected open val interceptions: Interceptions<S, A> = Interceptions()
 
     /**
      * [CoroutineDispatcher] to use for interception invocation, defaults to [Dispatchers.IO].

--- a/eiffel/src/test/java/com/etiennelenhart/eiffel/interception/AdapterTest.kt
+++ b/eiffel/src/test/java/com/etiennelenhart/eiffel/interception/AdapterTest.kt
@@ -17,7 +17,7 @@ class AdapterTest {
     @Test
     fun `GIVEN Adapter WHEN invoked with 'action' THEN adapted 'action' is forwarded`() = runBlocking {
         val expected = TestAction.Second
-        val adapter = adapter<TestState, TestAction> { _, _ -> expected }
+        val adapter = Adapter<TestState, TestAction> { _, _ -> expected }
 
         val actual = adapter(this, TestState, TestAction.First, {}, { _, _, action, _ -> action })
 

--- a/eiffel/src/test/java/com/etiennelenhart/eiffel/interception/FilterTest.kt
+++ b/eiffel/src/test/java/com/etiennelenhart/eiffel/interception/FilterTest.kt
@@ -18,7 +18,7 @@ class FilterTest {
     @Test
     fun `GIVEN Filter with passing 'predicate' WHEN invoked with 'action' THEN 'action' is forwarded`() = runBlocking {
         val expected = TestAction.Next
-        val filter = filter<TestState, TestAction> { _, action -> action is TestAction.Allow }
+        val filter = Filter<TestState, TestAction> { _, action -> action is TestAction.Allow }
 
         val actual = filter(this, TestState, TestAction.Allow, {}, { _, _, _, _ -> expected })
 
@@ -28,7 +28,7 @@ class FilterTest {
     @Test
     fun `GIVEN Filter with blocking 'predicate' WHEN invoked with 'action' THEN 'action' is blocked and 'null' is returned`() = runBlocking {
         val expected = null
-        val filter = filter<TestState, TestAction> { _, action -> action is TestAction.Allow }
+        val filter = Filter<TestState, TestAction> { _, action -> action is TestAction.Allow }
 
         val actual = filter(this, TestState, TestAction.Block, {}, { _, _, _, _ -> TestAction.Next })
 

--- a/eiffel/src/test/java/com/etiennelenhart/eiffel/interception/PipeTest.kt
+++ b/eiffel/src/test/java/com/etiennelenhart/eiffel/interception/PipeTest.kt
@@ -17,7 +17,7 @@ class PipeTest {
     @Test
     fun `GIVEN Pipe WHEN invoked with 'action' THEN 'action' is forwarded`() = runBlocking {
         val expected = TestAction.First
-        val pipe = pipe<TestState, TestAction>()
+        val pipe = Pipe<TestState, TestAction> { _, _ -> }
 
         val actual = pipe(this, TestState, expected, {}, { _, _, action, _ -> action })
 
@@ -27,7 +27,7 @@ class PipeTest {
     @Test
     fun `GIVEN Pipe WHEN invoked THEN 'before' is called before 'next'`() = runBlocking {
         var actual = ""
-        val pipe = pipe<TestState, TestAction>(before = { _, _ -> actual = "before" })
+        val pipe = Pipe<TestState, TestAction>(before = { _, _ -> actual = "before" })
 
         pipe(this, TestState, TestAction.First, {}, { _, _, action, _ -> if (actual.isEmpty()) actual = "next"; action })
 
@@ -37,7 +37,7 @@ class PipeTest {
     @Test
     fun `GIVEN Pipe WHEN invoked THEN 'after' is called after 'next'`() = runBlocking {
         var actual = ""
-        val pipe = pipe<TestState, TestAction>(after = { _, _ -> if (actual == "next") actual = "after" })
+        val pipe = Pipe<TestState, TestAction> { _, _ -> actual = "after" }
 
         pipe(this, TestState, TestAction.First, {}, { _, _, action, _ -> actual = "next"; action })
 
@@ -48,7 +48,7 @@ class PipeTest {
     fun `GIVEN Pipe WHEN invoked THEN 'before' is called with 'action'`() = runBlocking {
         val expected = TestAction.First
         var actual: TestAction? = null
-        val pipe = pipe<TestState, TestAction>(before = { _, action -> actual = action })
+        val pipe = Pipe<TestState, TestAction>(before = { _, action -> actual = action })
 
         pipe(this, TestState, expected, {}, { _, _, _, _ -> TestAction.Second })
 
@@ -59,7 +59,7 @@ class PipeTest {
     fun `GIVEN Pipe WHEN invoked THEN 'after' is called with action returned from 'next'`() = runBlocking {
         val expected = TestAction.Second
         var actual: TestAction? = null
-        val pipe = pipe<TestState, TestAction>(after = { _, action -> actual = action })
+        val pipe = Pipe<TestState, TestAction> { _, action -> actual = action }
 
         pipe(this, TestState, TestAction.First, {}, { _, _, _, _ -> expected })
 

--- a/eiffel/src/test/java/com/etiennelenhart/eiffel/interception/command/CommandTest.kt
+++ b/eiffel/src/test/java/com/etiennelenhart/eiffel/interception/command/CommandTest.kt
@@ -21,10 +21,10 @@ class CommandTest {
     @Test
     fun `GIVEN Command with consuming 'react' WHEN invoked with 'action' THEN 'immediateAction' is returned`() = runBlocking {
         val expected = TestAction.Loading
-        val command = command<TestState, TestAction> {
-            when (it) {
-                TestAction.Increment -> consuming(expected) { _, _ -> delay(20) }
-                else -> ignoring()
+        val command = Command<TestState, TestAction> { action ->
+            when (action) {
+                TestAction.Increment -> Reaction.Consuming(expected) { _, _ -> delay(20) }
+                else -> Reaction.Ignoring()
             }
         }
 
@@ -36,13 +36,13 @@ class CommandTest {
     @Test
     fun `GIVEN Command with consuming 'react' WHEN invoked with 'action' THEN 'dispatch' can be called in 'block'`() = runBlocking {
         val expected = TestAction.Add(1)
-        val command = command<TestState, TestAction> {
-            when (it) {
-                TestAction.Increment -> consuming(TestAction.Loading) { _, dispatch ->
+        val command = Command<TestState, TestAction> { action ->
+            when (action) {
+                TestAction.Increment -> Reaction.Consuming(TestAction.Loading) { _, dispatch ->
                     delay(40)
                     dispatch(expected)
                 }
-                else -> ignoring()
+                else -> Reaction.Ignoring()
             }
         }
 
@@ -56,10 +56,10 @@ class CommandTest {
     @Test
     fun `GIVEN Command with forwarding 'react' WHEN invoked with 'action' THEN 'action' is forwarded`() = runBlocking {
         val expected = TestAction.Loading
-        val command = command<TestState, TestAction> {
-            when (it) {
-                TestAction.Loading -> forwarding { _, _ -> delay(20) }
-                else -> ignoring()
+        val command = Command<TestState, TestAction> { action ->
+            when (action) {
+                TestAction.Loading -> Reaction.Forwarding { _, _ -> delay(20) }
+                else -> Reaction.Ignoring()
             }
         }
 
@@ -72,13 +72,13 @@ class CommandTest {
     @Test
     fun `GIVEN Command with forwarding 'react' WHEN invoked with 'action' THEN 'dispatch' can be called in 'block'`() = runBlocking {
         val expected = TestAction.Add(1)
-        val command = command<TestState, TestAction> {
-            when (it) {
-                TestAction.Increment -> forwarding { _, dispatch ->
+        val command = Command<TestState, TestAction> { action ->
+            when (action) {
+                TestAction.Increment -> Reaction.Forwarding { _, dispatch ->
                     delay(40)
                     dispatch(expected)
                 }
-                else -> ignoring()
+                else -> Reaction.Ignoring()
             }
         }
 
@@ -92,10 +92,10 @@ class CommandTest {
     @Test
     fun `GIVEN Command with ignoring 'react' WHEN invoked with 'action' THEN 'action' is forwarded`() = runBlocking {
         val expected = TestAction.Decrement
-        val command = command<TestState, TestAction> {
-            when (it) {
-                TestAction.Increment -> consuming(TestAction.Loading) { _, _ -> delay(20) }
-                else -> ignoring()
+        val command = Command<TestState, TestAction> { action ->
+            when (action) {
+                TestAction.Increment -> Reaction.Consuming(TestAction.Loading) { _, _ -> delay(20) }
+                else -> Reaction.Ignoring()
             }
         }
 

--- a/eiffel/src/test/java/com/etiennelenhart/eiffel/interception/command/LiveCommandTest.kt
+++ b/eiffel/src/test/java/com/etiennelenhart/eiffel/interception/command/LiveCommandTest.kt
@@ -24,10 +24,10 @@ class LiveCommandTest {
     @Test
     fun `GIVEN LiveCommand with consuming 'react' WHEN invoked with 'action' THEN 'immediateAction' is returned`() = runBlocking {
         val expected = TestAction.Loading
-        val command = liveCommand<TestState, TestAction> {
-            when (it) {
-                TestAction.Increment -> consuming(expected) { produce { delay(20) } }
-                else -> ignoring()
+        val command = LiveCommand<TestState, TestAction> { action ->
+            when (action) {
+                TestAction.Increment -> LiveReaction.Consuming(expected) { produce { delay(20) } }
+                else -> LiveReaction.Ignoring()
             }
         }
 
@@ -39,16 +39,16 @@ class LiveCommandTest {
     @Test
     fun `GIVEN LiveCommand with consuming 'react' WHEN invoked with 'action' THEN calling 'send' on channel causes dispatch`() = runBlocking {
         val expected = TestAction.Add(1)
-        val command = liveCommand<TestState, TestAction> {
-            when (it) {
-                TestAction.Increment -> consuming(TestAction.Loading) {
+        val command = LiveCommand<TestState, TestAction> { action ->
+            when (action) {
+                TestAction.Increment -> LiveReaction.Consuming(TestAction.Loading) {
                     produce {
                         delay(40)
                         send(expected)
                         close()
                     }
                 }
-                else -> ignoring()
+                else -> LiveReaction.Ignoring()
             }
         }
 
@@ -61,9 +61,9 @@ class LiveCommandTest {
 
     @Test
     fun `GIVEN LiveCommand with consuming 'react' WHEN invoked with 'action' THEN multiple 'send' calls on channel cause multiples dispatches`() = runBlocking {
-        val command = liveCommand<TestState, TestAction> {
-            when (it) {
-                TestAction.Increment -> consuming(TestAction.Loading) {
+        val command = LiveCommand<TestState, TestAction> { action ->
+            when (action) {
+                TestAction.Increment -> LiveReaction.Consuming(TestAction.Loading) {
                     produce {
                         send(TestAction.Add(1))
                         delay(40)
@@ -71,7 +71,7 @@ class LiveCommandTest {
                         close()
                     }
                 }
-                else -> ignoring()
+                else -> LiveReaction.Ignoring()
             }
         }
 
@@ -85,10 +85,10 @@ class LiveCommandTest {
     @Test
     fun `GIVEN LiveCommand with forwarding 'react' WHEN invoked with 'action' THEN 'action' is forwarded`() = runBlocking {
         val expected = TestAction.Loading
-        val command = liveCommand<TestState, TestAction> {
-            when (it) {
-                TestAction.Increment -> forwarding { produce { delay(20) } }
-                else -> ignoring()
+        val command = LiveCommand<TestState, TestAction> { action ->
+            when (action) {
+                TestAction.Increment -> LiveReaction.Forwarding { produce { delay(20) } }
+                else -> LiveReaction.Ignoring()
             }
         }
 
@@ -101,16 +101,16 @@ class LiveCommandTest {
     @Test
     fun `GIVEN LiveCommand with forwarding 'react' WHEN invoked with 'action' THEN calling 'send' on channel causes dispatch`() = runBlocking {
         val expected = TestAction.Add(1)
-        val command = liveCommand<TestState, TestAction> {
-            when (it) {
-                TestAction.Increment -> forwarding {
+        val command = LiveCommand<TestState, TestAction> { action ->
+            when (action) {
+                TestAction.Increment -> LiveReaction.Forwarding {
                     produce {
                         delay(40)
                         send(expected)
                         close()
                     }
                 }
-                else -> ignoring()
+                else -> LiveReaction.Ignoring()
             }
         }
 
@@ -124,9 +124,9 @@ class LiveCommandTest {
     @Test
     fun `GIVEN LiveCommand with forwarding 'react' WHEN invoked with 'action' THEN multiple 'send' calls on channel cause multiples dispatches`() =
         runBlocking {
-            val command = liveCommand<TestState, TestAction> {
-                when (it) {
-                    TestAction.Increment -> forwarding {
+            val command = LiveCommand<TestState, TestAction> { action ->
+                when (action) {
+                    TestAction.Increment -> LiveReaction.Forwarding {
                         produce {
                             send(TestAction.Add(1))
                             delay(40)
@@ -134,7 +134,7 @@ class LiveCommandTest {
                             close()
                         }
                     }
-                    else -> ignoring()
+                    else -> LiveReaction.Ignoring()
                 }
             }
 
@@ -148,10 +148,10 @@ class LiveCommandTest {
     @Test
     fun `GIVEN LiveCommand with ignoring 'react' WHEN invoked with 'action' THEN 'action' is forwarded`() = runBlocking {
         val expected = TestAction.Decrement
-        val command = liveCommand<TestState, TestAction> {
-            when (it) {
-                TestAction.Increment -> consuming(TestAction.Loading) { produce { delay(40) } }
-                else -> ignoring()
+        val command = LiveCommand<TestState, TestAction> { action ->
+            when (action) {
+                TestAction.Increment -> LiveReaction.Consuming(TestAction.Loading) { produce { delay(40) } }
+                else -> LiveReaction.Ignoring()
             }
         }
 

--- a/eiffel/src/test/java/com/etiennelenhart/eiffel/viewmodel/EiffelViewModelTest.kt
+++ b/eiffel/src/test/java/com/etiennelenhart/eiffel/viewmodel/EiffelViewModelTest.kt
@@ -3,6 +3,7 @@ package com.etiennelenhart.eiffel.viewmodel
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.LiveData
 import com.etiennelenhart.eiffel.interception.Interception
+import com.etiennelenhart.eiffel.interception.Interceptions
 import com.etiennelenhart.eiffel.interception.Next
 import com.etiennelenhart.eiffel.state.*
 import kotlinx.coroutines.CoroutineScope
@@ -196,7 +197,7 @@ class EiffelViewModelTest {
         @UseExperimental(ExperimentalCoroutinesApi::class)
         val viewModel = object : EiffelViewModel<InterceptionState, InterceptionAction>(InterceptionState(), Dispatchers.Unconfined) {
             override val update = interceptionStateUpdate
-            override val interceptions = listOf(firstInterception, secondInterception)
+            override val interceptions = Interceptions(firstInterception, secondInterception)
             override val interceptionDispatcher = Dispatchers.Unconfined
         }
 
@@ -224,7 +225,7 @@ class EiffelViewModelTest {
         @UseExperimental(ExperimentalCoroutinesApi::class)
         val viewModel = object : EiffelViewModel<InterceptionState, InterceptionAction>(InterceptionState(), Dispatchers.Unconfined) {
             override val update = interceptionStateUpdate
-            override val interceptions = listOf(blockingInterception, firstInterception, secondInterception)
+            override val interceptions = Interceptions(blockingInterception, firstInterception, secondInterception)
             override val interceptionDispatcher = Dispatchers.Unconfined
         }
 


### PR DESCRIPTION
Resolves #104.

@jordond Could you maybe take a look and check if this implementation would fit your needs? I tried to match some of your proposals while also allowing easy building with testable Interceptions and integrating it with `EiffelViewModel`.
It now allows composing the interceptions chain in three different ways.

Providing a list of `Interception` instances:
```kotlin
class TestableAdapter : Adapter<SampleState, SampleAction>() {
    override fun adapt(state: SampleState, action: SampleAction): SampleAction {
        return if (state.sample && action is SampleAction.DoSomething) {
            SampleAction.Adapted
        } else {
            action
        }
    }
}

class TestableFilter : Filter<SampleState, SampleAction>() {
    override fun predicate(state: SampleState, action: SampleAction): Boolean {
        return action !is SampleAction.IgnoreMe
    }
}

class TestablePipe : Pipe<SampleState, SampleAction>() {
    override fun after(state: SampleState, action: SampleAction?) {
        Log.d("Sample", "Chain result: $action")
    }
}

fun interceptions() = Interceptions(TestableAdapter(), TestableFilter(), TestablePipe())
```

Using the `Interceptions.Builder` class:
```kotlin
fun interceptions() = Interceptions.Builder<SampleState, SampleAction>()
    .add { TestableInterception() }
    .adapter { state, action ->
        if (state.sample && action is SampleAction.DoSomething) {
            SampleAction.Adapted
        } else {
            action
        }
    }
    .filter { _, action -> action !is SampleAction.IgnoreMe }
    .pipe { _, action -> Log.d("Sample", "Chain result: $action") }
    .build()
```

Using the DSL-like wrapper for the builder class:
```kotlin
fun interceptions() = interceptions<SampleState, SampleAction> {
    add { TestableInterception() }
    adapter { state, action ->
        if (state.sample && action is SampleAction.DoSomething) {
            SampleAction.Adapted
        } else {
            action
        }
    }
    filter { _, action -> action !is SampleAction.IgnoreMe }
    pipe { _, action -> Log.d("Sample", "Chain result: $action") }
}
```

`Interceptions` implements the `List<E>` interface by delegating to its chain so `EiffelViewModel` can still use it just as before.

I omitted your "on" style statements for now since I think it would make more sense to provide a full DSL for declaratively creating interceptions in the future. Something like this would be nice:
```kotlin
interceptions<SampleState, SampleAction> {
    adapter {
        on(SampleAction.DoSomething) {
            adaptTo { SampleAction.Adapted }
            whenState { sample == true }
        }
    }
    filter { 
        block { SampleAction.IgnoreMe }
    }
    pipe { 
        after { Log.d("Sample", "Chain result: $action") }
    }
}
```

But that will probably require a lot more work and consideration.