### PR TITLE
Fix: After pipe's Action type

### DIFF
--- a/eiffel/src/main/java/com/etiennelenhart/eiffel/interception/Interceptions.kt
+++ b/eiffel/src/main/java/com/etiennelenhart/eiffel/interception/Interceptions.kt
@@ -146,7 +146,7 @@ class Interceptions<S : State, A : Action>(chain: List<Interception<S, A>>) : Li
              *
              * *Note: `action` in [before] and [after] is already cast to [T].*
              */
-            fun pipe(debugName: String = "", before: (state: S, action: T) -> Unit = { _, _ -> }, after: (state: S, action: T?) -> Unit = {_, _ ->}) = apply {
+            fun pipe(debugName: String = "", before: (state: S, action: T) -> Unit = { _, _ -> }, after: (state: S, action: T) -> Unit = {_, _ ->}) = apply {
                 chain.add(
                     Pipe(
                         debugName,

--- a/eiffel/src/main/java/com/etiennelenhart/eiffel/interception/Interceptions.kt
+++ b/eiffel/src/main/java/com/etiennelenhart/eiffel/interception/Interceptions.kt
@@ -146,7 +146,7 @@ class Interceptions<S : State, A : Action>(chain: List<Interception<S, A>>) : Li
              *
              * *Note: `action` in [before] and [after] is already cast to [T].*
              */
-            fun pipe(debugName: String = "", before: (state: S, action: T) -> Unit = { _, _ -> }, after: (state: S, action: A?) -> Unit) = apply {
+            fun pipe(debugName: String = "", before: (state: S, action: T) -> Unit = { _, _ -> }, after: (state: S, action: T?) -> Unit = {_, _ ->}) = apply {
                 chain.add(
                     Pipe(
                         debugName,


### PR DESCRIPTION
We are casting the action `action as T`, but the lambda signature was still set to the original `A`.

I also added a default value for `after`.  Which has the benefit of being able to use `pipe(before={...})` without having to supply an after lambda as well.  This of course also allows the developer to just do `pipe()`, and nothing will happen...

I have a proposal PR coming, that might help with that.