### PR TITLE
Proposal: Before and After pipe builder

### DIFF
--- a/eiffel/src/main/java/com/etiennelenhart/eiffel/interception/Interceptions.kt
+++ b/eiffel/src/main/java/com/etiennelenhart/eiffel/interception/Interceptions.kt
@@ -170,7 +170,7 @@ class Interceptions<S : State, A : Action>(chain: List<Interception<S, A>>) : Li
              *
              * @see pipe
              */
-            fun pipeAfter(debugName: String = "", after: (state: S, action: T?) -> Unit) = apply {
+            fun pipeAfter(debugName: String = "", after: (state: S, action: T) -> Unit) = apply {
                 pipe(debugName, after = after)
             }
 

--- a/eiffel/src/main/java/com/etiennelenhart/eiffel/interception/Interceptions.kt
+++ b/eiffel/src/main/java/com/etiennelenhart/eiffel/interception/Interceptions.kt
@@ -161,7 +161,7 @@ class Interceptions<S : State, A : Action>(chain: List<Interception<S, A>>) : Li
              *
              * @see pipe
              */
-            fun beforePipe(debugName: String = "", before: (state: S, action: T) -> Unit) = apply {
+            fun pipeBefore(debugName: String = "", before: (state: S, action: T) -> Unit) = apply {
                 pipe(debugName, before)
             }
 
@@ -170,7 +170,7 @@ class Interceptions<S : State, A : Action>(chain: List<Interception<S, A>>) : Li
              *
              * @see pipe
              */
-            fun afterPipe(debugName: String = "", after: (state: S, action: T?) -> Unit) = apply {
+            fun pipeAfter(debugName: String = "", after: (state: S, action: T?) -> Unit) = apply {
                 pipe(debugName, after = after)
             }
 

--- a/eiffel/src/main/java/com/etiennelenhart/eiffel/interception/Interceptions.kt
+++ b/eiffel/src/main/java/com/etiennelenhart/eiffel/interception/Interceptions.kt
@@ -157,6 +157,24 @@ class Interceptions<S : State, A : Action>(chain: List<Interception<S, A>>) : Li
             }
 
             /**
+             * Creates a [Pipe] that only calls [before] for the targeted action.
+             *
+             * @see pipe
+             */
+            fun beforePipe(debugName: String = "", before: (state: S, action: T) -> Unit) = apply {
+                pipe(debugName, before)
+            }
+
+            /**
+             * Creates a [Pipe] that only calls [after] for the targeted action.
+             *
+             * @see pipe
+             */
+            fun afterPipe(debugName: String = "", after: (state: S, action: T?) -> Unit) = apply {
+                pipe(debugName, after = after)
+            }
+
+            /**
              * Creates a consuming [Command] that only calls [block] for the targeted action.
              *
              * *Note: [block] is additionally called with targeted `action`.*


### PR DESCRIPTION
I recently got around to refactor my codebase to use the new `Interceptions.Builder` syntax.  And found that all my `pipe`'s that I use are `before` pipes, and with the new syntax I had to constantly type

```kotlin
...
// I Just want the `before` pipe.
on<SomeAction> {
  pipe(before = { ... }, after = {_, _ -> })
} 
```

So I created #107 so that I could do:

```kotlin
on<SomeAction> {
  pipe(before = { ... })
} 
```

But it would be nice to use kotlin's "outside the parentheses" lambda syntax

```kotlin
on<SomeAction> {
  beforePipe { state, action ->
     // do work
  }
}
```

So I created a `beforePipe`, and a `afterPipe`.

Note: this relies on #107 