### PR TITLE
Feature - Ability to add custom interceptions to the targeted builder

### DIFF
--- a/eiffel/src/main/java/com/etiennelenhart/eiffel/interception/Interceptions.kt
+++ b/eiffel/src/main/java/com/etiennelenhart/eiffel/interception/Interceptions.kt
@@ -124,6 +124,16 @@ class Interceptions<S : State, A : Action>(chain: List<Interception<S, A>>) : Li
             private val chain = mutableListOf<Interception<S, A>>()
 
             /**
+             * Adds the given [interceptions] to the chain.
+             */
+            fun add(vararg interceptions: Interception<S, A>) = add(interceptions.toList())
+
+            /**
+             * Adds the given [interceptions] to the chain.
+             */
+            fun add(interceptions: List<Interception<S, A>>) = apply { chain.addAll(interceptions) }
+
+            /**
              * Creates an [Adapter] that only calls [adapt] for the targeted action.
              *
              * *Note: `action` in [adapt] is already cast to [T].*


### PR DESCRIPTION
In `Interceptions.Builder` there is a `add` function that allows adding custom interceptions using the DSL.  I have just added these functions to the `Interceptions.Targeted.Builder` as well.

This allows you to write custom `Interception`'s, and extension functions for them like:

```kotlin
// SampleInterception.kt

...

fun <S : State, A : Action> Interceptions.Builder<S, A>.sample(
    debugName: String = "",
    sample: (state: S, action: A) -> A
) = apply { add(Sample(debugName, sample)) }

inline fun <S : State, A : Action, reified T : A> Interceptions.Builder.Targeted<S, A, T>.sample(
    debugName: String = "",
    crossinline sample: (state: S, action: T) -> A
) = apply { 
    add(Sample(debugName) { state, action -> if (action is T) sample(state, action) else action }) 
}

// SampleViewModel
val interceptions = interceptions<SampleState, SampleAction> {
    sample { state, action -> ... }

    on<SomeAction> {
        sample { state, someAction -> ... }
    }
}
```
